### PR TITLE
Phase 3: Wire receipt photo upload in expense form

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,6 +47,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>拍攝收據或發票照片以附加到支出記錄</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>從相簿選擇收據或發票照片以附加到支出記錄</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/providers/balance_provider.dart
+++ b/lib/providers/balance_provider.dart
@@ -3,6 +3,7 @@ import 'package:isar/isar.dart';
 import '../models/expense.dart';
 import '../models/balance.dart';
 import '../models/family_member.dart';
+import '../models/settlement.dart';
 import '../services/database_service.dart';
 import '../services/split_calculator.dart';
 
@@ -14,7 +15,8 @@ final balancesProvider = StreamProvider<List<Balance>>((ref) async* {
 final simplifiedDebtsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
   final isar = await DatabaseService.instance;
   final expenses = await isar.expenses.filter().isSharedEqualTo(true).findAll();
-  final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: []);
+  final settlements = await isar.settlements.where().findAll();
+  final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: settlements);
   final simplified = SplitCalculator.simplifyDebts(netDebts);
   final members = await isar.familyMembers.where().findAll();
   final nameMap = {for (final m in members) m.id: m.name};
@@ -30,7 +32,8 @@ final simplifiedDebtsProvider = FutureProvider<List<Map<String, dynamic>>>((ref)
 final memberNetBalanceProvider = FutureProvider<Map<String, double>>((ref) async {
   final isar = await DatabaseService.instance;
   final expenses = await isar.expenses.filter().isSharedEqualTo(true).findAll();
-  final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: []);
+  final settlements = await isar.settlements.where().findAll();
+  final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: settlements);
   final Map<String, double> balances = {};
   netDebts.forEach((key, amount) {
     final parts = key.split('->');
@@ -53,9 +56,10 @@ class BalanceNotifier extends AsyncNotifier<void> {
     final groupId = await DatabaseService.getPrimaryGroupId();
     if (groupId == null) return;
     final expenses = await isar.expenses.filter().isSharedEqualTo(true).findAll();
+    final settlements = await isar.settlements.where().findAll();
     final members = await isar.familyMembers.where().findAll();
     final nameMap = {for (final m in members) m.id: m.name};
-    final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: []);
+    final netDebts = SplitCalculator.calculateNetDebts(expenses: expenses, settlements: settlements);
     final now = DateTime.now();
     await isar.writeTxn(() async {
       await isar.balances.filter().groupIdEqualTo(groupId).deleteAll();

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -80,6 +80,17 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     }
   }
 
+  Future<void> updateExpense(Expense expense) async {
+    final isar = await DatabaseService.instance;
+    expense.updatedAt = DateTime.now();
+    await isar.writeTxn(() async {
+      await isar.expenses.put(expense);
+    });
+    if (expense.isShared) {
+      await ref.read(balanceNotifierProvider.notifier).recalculate();
+    }
+  }
+
   Future<void> deleteExpense(Expense expense) async {
     final isar = await DatabaseService.instance;
     final wasShared = expense.isShared;

--- a/lib/providers/settlement_provider.dart
+++ b/lib/providers/settlement_provider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar/isar.dart';
+import 'package:uuid/uuid.dart';
+import '../models/settlement.dart';
+import '../services/database_service.dart';
+import 'balance_provider.dart';
+
+const _uuid = Uuid();
+
+final allSettlementsProvider = StreamProvider<List<Settlement>>((ref) async* {
+  final isar = await DatabaseService.instance;
+  yield* isar.settlements.where().sortByDateDesc().watch(fireImmediately: true);
+});
+
+final settlementNotifierProvider =
+    AsyncNotifierProvider<SettlementNotifier, void>(SettlementNotifier.new);
+
+class SettlementNotifier extends AsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> addSettlement({
+    required String fromMemberId,
+    required String fromMemberName,
+    required String toMemberId,
+    required String toMemberName,
+    required double amount,
+    String? note,
+  }) async {
+    final isar = await DatabaseService.instance;
+    final groupId = await DatabaseService.getPrimaryGroupId();
+    if (groupId == null) return;
+    final now = DateTime.now();
+    final settlement = Settlement()
+      ..id = _uuid.v4()
+      ..groupId = groupId
+      ..fromMemberId = fromMemberId
+      ..fromMemberName = fromMemberName
+      ..toMemberId = toMemberId
+      ..toMemberName = toMemberName
+      ..amount = amount
+      ..note = note
+      ..date = now
+      ..createdAt = now;
+    await isar.writeTxn(() async {
+      await isar.settlements.put(settlement);
+    });
+    await ref.read(balanceNotifierProvider.notifier).recalculate();
+  }
+
+  Future<void> deleteSettlement(Settlement settlement) async {
+    final isar = await DatabaseService.instance;
+    await isar.writeTxn(() async {
+      await isar.settlements.delete(settlement.isarId);
+    });
+    await ref.read(balanceNotifierProvider.notifier).recalculate();
+  }
+}

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -7,7 +7,6 @@ import '../../models/enums.dart';
 import '../../models/expense.dart';
 import '../../models/split_detail.dart';
 import '../../models/family_member.dart';
-import '../../models/category.dart';
 import '../../providers/member_provider.dart';
 import '../../providers/expense_provider.dart';
 import '../../providers/category_provider.dart';
@@ -36,6 +35,39 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   Map<String, TextEditingController> _pctCtrl = {};
   Map<String, TextEditingController> _customCtrl = {};
 
+  bool get _isEditing => widget.existingExpense != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existingExpense;
+    if (e != null) {
+      _descController.text = e.description;
+      _amountController.text = e.amount.toStringAsFixed(0);
+      _noteController.text = e.note ?? '';
+      _selectedDate = e.date;
+      _selectedCategory = e.category;
+      _isShared = e.isShared;
+      _splitMethod = e.splitMethod;
+      _payerId = e.payerId;
+      _participantIds = e.splits.where((s) => s.isParticipant).map((s) => s.memberId).toSet();
+      if (_splitMethod == SplitMethod.percentage) {
+        final total = e.amount;
+        for (final s in e.splits.where((s) => s.isParticipant)) {
+          final pct = total > 0 ? s.shareAmount / total * 100 : 0.0;
+          _percentages[s.memberId] = pct;
+          _pctCtrl[s.memberId] = TextEditingController(text: pct.toStringAsFixed(0));
+        }
+      }
+      if (_splitMethod == SplitMethod.custom) {
+        for (final s in e.splits.where((s) => s.isParticipant)) {
+          _customAmounts[s.memberId] = s.shareAmount;
+          _customCtrl[s.memberId] = TextEditingController(text: s.shareAmount.toStringAsFixed(0));
+        }
+      }
+    }
+  }
+
   @override
   void dispose() {
     _descController.dispose();
@@ -54,7 +86,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
     final currentUser = ref.watch(currentUserProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('新增支出')),
+      appBar: AppBar(title: Text(_isEditing ? '編輯支出' : '新增支出')),
       body: members.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('錯誤：$e')),
@@ -63,7 +95,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
             return Center(child: Padding(
               padding: const EdgeInsets.all(32),
               child: Column(mainAxisSize: MainAxisSize.min, children: [
-                Icon(Icons.people_outline, size: 64, color: theme.colorScheme.primary.withOpacity(0.3)),
+                Icon(Icons.people_outline, size: 64, color: theme.colorScheme.primary.withValues(alpha:0.3)),
                 const Gap(16),
                 Text('尚未建立家庭成員', style: theme.textTheme.titleMedium),
                 const Gap(8),
@@ -210,7 +242,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
                   if (amount <= 0) return const SizedBox.shrink();
                   final pCount = _participantIds.length;
                   return Card(
-                    color: theme.colorScheme.primaryContainer.withOpacity(0.3),
+                    color: theme.colorScheme.primaryContainer.withValues(alpha:0.3),
                     child: Padding(padding: const EdgeInsets.all(12), child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start, children: [
                         Row(children: [
@@ -246,8 +278,8 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
               // 儲存
               FilledButton.icon(
                 onPressed: () => _save(memberList),
-                icon: const Icon(Icons.add),
-                label: const Text('新增支出'),
+                icon: Icon(_isEditing ? Icons.save : Icons.add),
+                label: Text(_isEditing ? '儲存變更' : '新增支出'),
                 style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
               ),
               const Gap(32),
@@ -305,17 +337,33 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
           break;
       }
     }
-    await ref.read(expenseNotifierProvider.notifier).addExpense(
-      date: _selectedDate, description: _descController.text.trim(),
-      amount: amount, category: _selectedCategory, isShared: _isShared,
-      splitMethod: _splitMethod, payerId: _payerId!,
-      payerName: nameMap[_payerId] ?? '', splits: splits,
-      note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
-      createdBy: currentUser?.id ?? _payerId!,
-    );
+    if (_isEditing) {
+      final existing = widget.existingExpense!;
+      existing
+        ..date = _selectedDate
+        ..description = _descController.text.trim()
+        ..amount = amount
+        ..category = _selectedCategory
+        ..isShared = _isShared
+        ..splitMethod = _splitMethod
+        ..payerId = _payerId!
+        ..payerName = nameMap[_payerId] ?? ''
+        ..splits = splits
+        ..note = _noteController.text.trim().isEmpty ? null : _noteController.text.trim();
+      await ref.read(expenseNotifierProvider.notifier).updateExpense(existing);
+    } else {
+      await ref.read(expenseNotifierProvider.notifier).addExpense(
+        date: _selectedDate, description: _descController.text.trim(),
+        amount: amount, category: _selectedCategory, isShared: _isShared,
+        splitMethod: _splitMethod, payerId: _payerId!,
+        payerName: nameMap[_payerId] ?? '', splits: splits,
+        note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
+        createdBy: currentUser?.id ?? _payerId!,
+      );
+    }
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('已新增支出'), behavior: SnackBarBehavior.floating));
+          SnackBar(content: Text(_isEditing ? '已更新支出' : '已新增支出'), behavior: SnackBarBehavior.floating));
       Navigator.pop(context);
     }
   }

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -1,6 +1,8 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:gap/gap.dart';
 import '../../models/enums.dart';
@@ -10,6 +12,7 @@ import '../../models/family_member.dart';
 import '../../providers/member_provider.dart';
 import '../../providers/expense_provider.dart';
 import '../../providers/category_provider.dart';
+import '../../services/image_storage_service.dart';
 
 class ExpenseFormPage extends ConsumerStatefulWidget {
   final Expense? existingExpense;
@@ -34,6 +37,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   Map<String, double> _customAmounts = {};
   Map<String, TextEditingController> _pctCtrl = {};
   Map<String, TextEditingController> _customCtrl = {};
+  String? _receiptPath;
 
   bool get _isEditing => widget.existingExpense != null;
 
@@ -50,6 +54,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       _isShared = e.isShared;
       _splitMethod = e.splitMethod;
       _payerId = e.payerId;
+      _receiptPath = e.receiptPath;
       _participantIds = e.splits.where((s) => s.isParticipant).map((s) => s.memberId).toSet();
       if (_splitMethod == SplitMethod.percentage) {
         final total = e.amount;
@@ -274,6 +279,42 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
                   decoration: const InputDecoration(labelText: '備註（可選）',
                       prefixIcon: Icon(Icons.note_outlined), border: OutlineInputBorder()),
                   maxLines: 2),
+              const Gap(16),
+              // 收據照片
+              Text('收據 / 發票照片', style: theme.textTheme.labelLarge),
+              const Gap(8),
+              if (_receiptPath != null) ...[
+                Stack(children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: Image.file(File(_receiptPath!),
+                        height: 200, width: double.infinity, fit: BoxFit.cover),
+                  ),
+                  Positioned(top: 8, right: 8, child: Row(mainAxisSize: MainAxisSize.min, children: [
+                    _CircleIconButton(
+                      icon: Icons.fullscreen,
+                      onTap: () => _viewReceiptFullScreen(_receiptPath!),
+                    ),
+                    const Gap(8),
+                    _CircleIconButton(
+                      icon: Icons.close,
+                      onTap: () => setState(() => _receiptPath = null),
+                    ),
+                  ])),
+                ]),
+                const Gap(8),
+                OutlinedButton.icon(
+                  onPressed: _pickReceipt,
+                  icon: const Icon(Icons.swap_horiz, size: 18),
+                  label: const Text('更換照片'),
+                ),
+              ] else
+                OutlinedButton.icon(
+                  onPressed: _pickReceipt,
+                  icon: const Icon(Icons.camera_alt_outlined, size: 18),
+                  label: const Text('拍照或選擇照片'),
+                  style: OutlinedButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+                ),
               const Gap(32),
               // 儲存
               FilledButton.icon(
@@ -288,6 +329,35 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         },
       ),
     );
+  }
+
+  Future<void> _pickReceipt() async {
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (ctx) => SafeArea(child: Column(mainAxisSize: MainAxisSize.min, children: [
+        ListTile(leading: const Icon(Icons.camera_alt), title: const Text('拍照'),
+            onTap: () => Navigator.pop(ctx, ImageSource.camera)),
+        ListTile(leading: const Icon(Icons.photo_library), title: const Text('從相簿選擇'),
+            onTap: () => Navigator.pop(ctx, ImageSource.gallery)),
+      ])),
+    );
+    if (source == null) return;
+    final picked = await ImagePicker().pickImage(source: source, maxWidth: 1920, imageQuality: 85);
+    if (picked == null) return;
+    final saved = await ImageStorageService.saveReceipt(picked.path);
+    setState(() => _receiptPath = saved);
+  }
+
+  void _viewReceiptFullScreen(String path) {
+    Navigator.push(context, MaterialPageRoute(
+      builder: (_) => Scaffold(
+        backgroundColor: Colors.black,
+        appBar: AppBar(backgroundColor: Colors.transparent, foregroundColor: Colors.white),
+        body: Center(child: InteractiveViewer(
+          child: Image.file(File(path)),
+        )),
+      ),
+    ));
   }
 
   Future<void> _save(List<FamilyMember> members) async {
@@ -349,6 +419,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         ..payerId = _payerId!
         ..payerName = nameMap[_payerId] ?? ''
         ..splits = splits
+        ..receiptPath = _receiptPath
         ..note = _noteController.text.trim().isEmpty ? null : _noteController.text.trim();
       await ref.read(expenseNotifierProvider.notifier).updateExpense(existing);
     } else {
@@ -357,6 +428,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         amount: amount, category: _selectedCategory, isShared: _isShared,
         splitMethod: _splitMethod, payerId: _payerId!,
         payerName: nameMap[_payerId] ?? '', splits: splits,
+        receiptPath: _receiptPath,
         note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
         createdBy: currentUser?.id ?? _payerId!,
       );
@@ -366,5 +438,26 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
           SnackBar(content: Text(_isEditing ? '已更新支出' : '已新增支出'), behavior: SnackBarBehavior.floating));
       Navigator.pop(context);
     }
+  }
+}
+
+class _CircleIconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  const _CircleIconButton({required this.icon, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 32, height: 32,
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.5),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(icon, color: Colors.white, size: 18),
+      ),
+    );
   }
 }

--- a/lib/screens/home/home_page.dart
+++ b/lib/screens/home/home_page.dart
@@ -6,6 +6,8 @@ import '../../models/expense.dart';
 import '../../providers/expense_provider.dart';
 import '../../providers/member_provider.dart';
 import '../../providers/balance_provider.dart';
+import '../../utils/formatters.dart';
+import '../../widgets/member_avatar.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -49,13 +51,13 @@ class HomePage extends ConsumerWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(Icons.family_restroom, size: 80,
-                        color: theme.colorScheme.primary.withOpacity(0.3)),
+                        color: theme.colorScheme.primary.withValues(alpha: 0.3)),
                     const Gap(24),
                     Text('歡迎使用家計本！', style: theme.textTheme.headlineSmall),
                     const Gap(8),
                     Text('請先到「設定」新增家庭成員',
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurface.withOpacity(0.6),
+                          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                         )),
                   ],
                 ),
@@ -92,7 +94,7 @@ class HomePage extends ConsumerWidget {
               child: Text('切換身份', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
             ),
             ...members.map((m) => ListTile(
-                  leading: CircleAvatar(child: Text(m.name[0])),
+                  leading: MemberAvatar(name: m.name, size: 40),
                   title: Text(m.name),
                   trailing: m.isCurrentUser ? const Icon(Icons.check, color: Colors.green) : null,
                   onTap: () {
@@ -132,23 +134,23 @@ class _MonthlySummaryCard extends StatelessWidget {
               Text(monthLabel, style: theme.textTheme.titleMedium),
             ]),
             const Gap(16),
-            Text('NT\$ ${NumberFormat('#,##0').format(total)}',
+            Text(Formatters.currency(total),
                 style: theme.textTheme.headlineMedium?.copyWith(
                     fontWeight: FontWeight.bold, color: theme.colorScheme.primary)),
             const Gap(4),
             Text('本月總支出', style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.6))),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6))),
             const Gap(16),
             Row(children: [
-              Expanded(child: _MiniStat(label: '共同支出', value: 'NT\$ ${NumberFormat('#,##0').format(sharedTotal)}',
+              Expanded(child: _MiniStat(label: '共同支出', value: Formatters.currency(sharedTotal),
                   icon: Icons.people, color: theme.colorScheme.tertiary)),
               const Gap(12),
-              Expanded(child: _MiniStat(label: '個人支出', value: 'NT\$ ${NumberFormat('#,##0').format(personalTotal)}',
+              Expanded(child: _MiniStat(label: '個人支出', value: Formatters.currency(personalTotal),
                   icon: Icons.person, color: theme.colorScheme.secondary)),
             ]),
             const Gap(8),
             Text('共 ${expenses.length} 筆記錄', style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
           ],
         ),
       ),
@@ -166,7 +168,7 @@ class _MiniStat extends StatelessWidget {
     final theme = Theme.of(context);
     return Container(
       padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(color: color.withOpacity(0.1), borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(color: color.withValues(alpha: 0.1), borderRadius: BorderRadius.circular(12)),
       child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
         Row(children: [
           Icon(icon, size: 14, color: color),
@@ -198,26 +200,26 @@ class _DebtOverviewCard extends StatelessWidget {
           const Gap(12),
           if (debts.isEmpty)
             Text('目前沒有未結清的債務 🎉', style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.6)))
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6)))
           else
             ...debts.map((d) => Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
                   child: Row(children: [
                     Container(
                       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(color: theme.colorScheme.error.withOpacity(0.1), borderRadius: BorderRadius.circular(8)),
+                      decoration: BoxDecoration(color: theme.colorScheme.error.withValues(alpha: 0.1), borderRadius: BorderRadius.circular(8)),
                       child: Text(d['fromName'] as String, style: TextStyle(color: theme.colorScheme.error, fontWeight: FontWeight.w600, fontSize: 13)),
                     ),
                     const Gap(8),
-                    Icon(Icons.arrow_forward, size: 16, color: theme.colorScheme.onSurface.withOpacity(0.4)),
+                    Icon(Icons.arrow_forward, size: 16, color: theme.colorScheme.onSurface.withValues(alpha: 0.4)),
                     const Gap(8),
                     Container(
                       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(color: Colors.green.withOpacity(0.1), borderRadius: BorderRadius.circular(8)),
+                      decoration: BoxDecoration(color: Colors.green.withValues(alpha: 0.1), borderRadius: BorderRadius.circular(8)),
                       child: Text(d['toName'] as String, style: const TextStyle(color: Colors.green, fontWeight: FontWeight.w600, fontSize: 13)),
                     ),
                     const Spacer(),
-                    Text('NT\$ ${NumberFormat('#,##0').format(d['amount'])}',
+                    Text(Formatters.currency(d['amount'] as num),
                         style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
                   ]),
                 )),
@@ -245,7 +247,7 @@ class _RecentExpensesCard extends StatelessWidget {
           const Gap(12),
           if (expenses.isEmpty)
             Text('還沒有任何記錄，點下方「記帳」開始！', style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.6)))
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6)))
           else
             ...expenses.map((e) => Padding(
                   padding: const EdgeInsets.symmetric(vertical: 6),
@@ -260,9 +262,9 @@ class _RecentExpensesCard extends StatelessWidget {
                     Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
                       Text(e.description, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500)),
                       Text('${DateFormat('MM/dd').format(e.date)} · ${e.category} · ${e.payerName}付',
-                          style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                          style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
                     ])),
-                    Text('NT\$ ${NumberFormat('#,##0').format(e.amount)}',
+                    Text(Formatters.currency(e.amount),
                         style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
                   ]),
                 )),

--- a/lib/screens/records/records_page.dart
+++ b/lib/screens/records/records_page.dart
@@ -5,6 +5,8 @@ import 'package:intl/intl.dart';
 import 'package:gap/gap.dart';
 import '../../models/expense.dart';
 import '../../providers/expense_provider.dart';
+import '../../utils/formatters.dart';
+import '../expense/expense_form_page.dart';
 
 class RecordsPage extends ConsumerStatefulWidget {
   const RecordsPage({super.key});
@@ -14,7 +16,6 @@ class RecordsPage extends ConsumerStatefulWidget {
 
 class _RecordsPageState extends ConsumerState<RecordsPage> {
   String _filterType = '全部'; // 全部 / 共同 / 個人
-  String? _filterCategory;
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +48,7 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
           if (filtered.isEmpty) {
             return Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
               Icon(Icons.receipt_long_outlined, size: 64,
-                  color: theme.colorScheme.primary.withOpacity(0.3)),
+                  color: theme.colorScheme.primary.withValues(alpha: 0.3)),
               const Gap(16),
               Text('沒有記錄', style: theme.textTheme.titleMedium),
             ]));
@@ -75,12 +76,23 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                     Text(dateKey, style: theme.textTheme.labelLarge?.copyWith(
                         color: theme.colorScheme.primary)),
                     const Spacer(),
-                    Text('NT\$ ${NumberFormat('#,##0').format(dayTotal)}',
+                    Text(Formatters.currency(dayTotal),
                         style: theme.textTheme.labelMedium?.copyWith(
-                            color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                            color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
                   ]),
                 ),
                 ...items.map((e) => Slidable(
+                      startActionPane: ActionPane(motion: const DrawerMotion(), children: [
+                        SlidableAction(
+                          onPressed: (_) => Navigator.push(context,
+                              MaterialPageRoute(builder: (_) => ExpenseFormPage(existingExpense: e))),
+                          backgroundColor: theme.colorScheme.primary,
+                          foregroundColor: theme.colorScheme.onPrimary,
+                          icon: Icons.edit,
+                          label: '編輯',
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ]),
                       endActionPane: ActionPane(motion: const DrawerMotion(), children: [
                         SlidableAction(
                           onPressed: (_) => _confirmDelete(e),
@@ -94,6 +106,8 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                       child: Card(
                         margin: const EdgeInsets.only(bottom: 8),
                         child: ListTile(
+                          onTap: () => Navigator.push(context,
+                              MaterialPageRoute(builder: (_) => ExpenseFormPage(existingExpense: e))),
                           leading: Container(
                             width: 40, height: 40,
                             decoration: BoxDecoration(
@@ -104,7 +118,7 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                           ),
                           title: Text(e.description),
                           subtitle: Text('${e.category} · ${e.payerName}付${e.isShared ? ' · 共同' : ''}'),
-                          trailing: Text('NT\$ ${NumberFormat('#,##0').format(e.amount)}',
+                          trailing: Text(Formatters.currency(e.amount),
                               style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
                         ),
                       ),

--- a/lib/screens/records/records_page.dart
+++ b/lib/screens/records/records_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
@@ -117,7 +118,14 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                             child: Text(e.isShared ? '👥' : '👤', style: const TextStyle(fontSize: 18)),
                           ),
                           title: Text(e.description),
-                          subtitle: Text('${e.category} · ${e.payerName}付${e.isShared ? ' · 共同' : ''}'),
+                          subtitle: Row(children: [
+                            Expanded(child: Text('${e.category} · ${e.payerName}付${e.isShared ? ' · 共同' : ''}')),
+                            if (e.receiptPath != null) GestureDetector(
+                              onTap: () => _viewReceipt(e.receiptPath!),
+                              child: Icon(Icons.receipt_long, size: 16,
+                                  color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                            ),
+                          ]),
                           trailing: Text(Formatters.currency(e.amount),
                               style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
                         ),
@@ -130,6 +138,19 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
         },
       ),
     );
+  }
+
+  void _viewReceipt(String path) {
+    Navigator.push(context, MaterialPageRoute(
+      builder: (_) => Scaffold(
+        backgroundColor: Colors.black,
+        appBar: AppBar(backgroundColor: Colors.transparent, foregroundColor: Colors.white,
+            title: const Text('收據照片')),
+        body: Center(child: InteractiveViewer(
+          child: Image.file(File(path)),
+        )),
+      ),
+    ));
   }
 
   void _confirmDelete(Expense expense) {

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -59,11 +59,11 @@ class SettingsPage extends ConsumerWidget {
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       child: Column(children: [
                         Icon(Icons.person_add, size: 48,
-                            color: theme.colorScheme.primary.withOpacity(0.3)),
+                            color: theme.colorScheme.primary.withValues(alpha:0.3)),
                         const Gap(8),
                         Text('還沒有成員，請點右上角新增',
                             style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurface.withOpacity(0.6))),
+                                color: theme.colorScheme.onSurface.withValues(alpha:0.6))),
                       ]),
                     );
                   }
@@ -88,12 +88,12 @@ class SettingsPage extends ConsumerWidget {
                         ),
                       IconButton(
                         icon: Icon(Icons.edit_outlined, size: 20,
-                            color: theme.colorScheme.onSurface.withOpacity(0.5)),
+                            color: theme.colorScheme.onSurface.withValues(alpha:0.5)),
                         onPressed: () => _showEditMemberDialog(context, ref, m.id, m.name),
                       ),
                       IconButton(
                         icon: Icon(Icons.delete_outline, size: 20,
-                            color: theme.colorScheme.error.withOpacity(0.5)),
+                            color: theme.colorScheme.error.withValues(alpha:0.5)),
                         onPressed: () => _confirmDeleteMember(context, ref, m.id, m.name),
                       ),
                     ]),

--- a/lib/screens/split/split_overview_page.dart
+++ b/lib/screens/split/split_overview_page.dart
@@ -1,15 +1,99 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:gap/gap.dart';
 import '../../providers/balance_provider.dart';
 import '../../providers/member_provider.dart';
+import '../../providers/settlement_provider.dart';
+import '../../utils/formatters.dart';
+import '../../widgets/member_avatar.dart';
 
-class SplitOverviewPage extends ConsumerWidget {
+class SplitOverviewPage extends ConsumerStatefulWidget {
   const SplitOverviewPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SplitOverviewPage> createState() => _SplitOverviewPageState();
+}
+
+class _SplitOverviewPageState extends ConsumerState<SplitOverviewPage> {
+  void _showSettlementDialog(Map<String, dynamic> debt) {
+    final amountController = TextEditingController(
+      text: (debt['amount'] as num).toStringAsFixed(0),
+    );
+    final noteController = TextEditingController();
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return Padding(
+          padding: EdgeInsets.only(
+            left: 24, right: 24, top: 24,
+            bottom: MediaQuery.of(ctx).viewInsets.bottom + 24,
+          ),
+          child: Column(mainAxisSize: MainAxisSize.min, children: [
+            Text('記錄付款', style: theme.textTheme.titleLarge),
+            const Gap(16),
+            Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+              MemberAvatar(name: debt['fromName'] as String, size: 40),
+              const Gap(8),
+              Text(debt['fromName'] as String,
+                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+              const Gap(12),
+              const Icon(Icons.arrow_right_alt, size: 28),
+              const Gap(12),
+              MemberAvatar(name: debt['toName'] as String, size: 40),
+              const Gap(8),
+              Text(debt['toName'] as String,
+                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+            ]),
+            const Gap(20),
+            TextField(
+              controller: amountController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: '金額',
+                prefixText: 'NT\$ ',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const Gap(12),
+            TextField(
+              controller: noteController,
+              decoration: const InputDecoration(
+                labelText: '備註（選填）',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const Gap(20),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () async {
+                  final amount = double.tryParse(amountController.text);
+                  if (amount == null || amount <= 0) return;
+                  await ref.read(settlementNotifierProvider.notifier).addSettlement(
+                    fromMemberId: debt['from'] as String,
+                    fromMemberName: debt['fromName'] as String,
+                    toMemberId: debt['to'] as String,
+                    toMemberName: debt['toName'] as String,
+                    amount: amount,
+                    note: noteController.text.isEmpty ? null : noteController.text,
+                  );
+                  if (ctx.mounted) Navigator.pop(ctx);
+                },
+                icon: const Icon(Icons.check),
+                label: const Text('確認付款'),
+              ),
+            ),
+          ]),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final simplifiedDebts = ref.watch(simplifiedDebtsProvider);
     final netBalances = ref.watch(memberNetBalanceProvider);
@@ -32,7 +116,7 @@ class SplitOverviewPage extends ConsumerWidget {
               const Gap(4),
               Text('正數 = 被欠（可收錢），負數 = 欠人（需還錢）',
                   style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
               const Gap(16),
               netBalances.when(
                 loading: () => const Center(child: CircularProgressIndicator()),
@@ -40,7 +124,7 @@ class SplitOverviewPage extends ConsumerWidget {
                 data: (balances) {
                   if (balances.isEmpty) {
                     return Text('目前沒有任何拆帳記錄', style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withOpacity(0.6)));
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.6)));
                   }
                   final memberList = members.valueOrNull ?? [];
                   final nameMap = {for (final m in memberList) m.id: m.name};
@@ -51,19 +135,11 @@ class SplitOverviewPage extends ConsumerWidget {
                     return Padding(
                       padding: const EdgeInsets.symmetric(vertical: 6),
                       child: Row(children: [
-                        CircleAvatar(
-                          radius: 18,
-                          backgroundColor: isPositive
-                              ? Colors.green.withOpacity(0.1)
-                              : theme.colorScheme.error.withOpacity(0.1),
-                          child: Text(name[0], style: TextStyle(
-                              color: isPositive ? Colors.green : theme.colorScheme.error,
-                              fontWeight: FontWeight.w600)),
-                        ),
+                        MemberAvatar(name: name, size: 36),
                         const Gap(12),
                         Expanded(child: Text(name, style: theme.textTheme.bodyLarge)),
                         Text(
-                          '${isPositive ? '+' : ''}NT\$ ${NumberFormat('#,##0').format(e.value)}',
+                          Formatters.signedCurrency(e.value),
                           style: theme.textTheme.titleSmall?.copyWith(
                               fontWeight: FontWeight.bold,
                               color: isPositive ? Colors.green : theme.colorScheme.error),
@@ -88,7 +164,7 @@ class SplitOverviewPage extends ConsumerWidget {
               const Gap(4),
               Text('最少轉帳次數即可結清所有債務',
                   style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
               const Gap(16),
               simplifiedDebts.when(
                 loading: () => const Center(child: CircularProgressIndicator()),
@@ -96,7 +172,7 @@ class SplitOverviewPage extends ConsumerWidget {
                 data: (debts) {
                   if (debts.isEmpty) {
                     return Text('所有人帳目已結清 🎉', style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withOpacity(0.6)));
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.6)));
                   }
                   return Column(children: debts.asMap().entries.map((entry) {
                     final i = entry.key;
@@ -105,28 +181,40 @@ class SplitOverviewPage extends ConsumerWidget {
                       margin: const EdgeInsets.only(bottom: 12),
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
-                        color: theme.colorScheme.surfaceContainerHighest.withOpacity(0.5),
+                        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
                         borderRadius: BorderRadius.circular(12),
                       ),
-                      child: Row(children: [
-                        Container(
-                          width: 28, height: 28,
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.primary, shape: BoxShape.circle),
-                          alignment: Alignment.center,
-                          child: Text('${i + 1}', style: TextStyle(
-                              color: theme.colorScheme.onPrimary, fontWeight: FontWeight.bold, fontSize: 13)),
+                      child: Column(children: [
+                        Row(children: [
+                          Container(
+                            width: 28, height: 28,
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.primary, shape: BoxShape.circle),
+                            alignment: Alignment.center,
+                            child: Text('${i + 1}', style: TextStyle(
+                                color: theme.colorScheme.onPrimary, fontWeight: FontWeight.bold, fontSize: 13)),
+                          ),
+                          const Gap(12),
+                          Text(d['fromName'] as String, style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)),
+                          const Gap(8),
+                          const Icon(Icons.arrow_right_alt, size: 24),
+                          const Gap(8),
+                          Expanded(
+                            child: Text(d['toName'] as String, style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)),
+                          ),
+                          Text(Formatters.currency(d['amount'] as num),
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.bold, color: theme.colorScheme.primary)),
+                        ]),
+                        const Gap(8),
+                        SizedBox(
+                          width: double.infinity,
+                          child: OutlinedButton.icon(
+                            onPressed: () => _showSettlementDialog(d),
+                            icon: const Icon(Icons.payments_outlined, size: 18),
+                            label: const Text('記錄付款'),
+                          ),
                         ),
-                        const Gap(12),
-                        Text(d['fromName'] as String, style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)),
-                        const Gap(8),
-                        const Icon(Icons.arrow_right_alt, size: 24),
-                        const Gap(8),
-                        Text(d['toName'] as String, style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)),
-                        const Spacer(),
-                        Text('NT\$ ${NumberFormat('#,##0').format(d['amount'])}',
-                            style: theme.textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold, color: theme.colorScheme.primary)),
                       ]),
                     );
                   }).toList());

--- a/lib/screens/statistics/statistics_page.dart
+++ b/lib/screens/statistics/statistics_page.dart
@@ -3,10 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
 import 'package:gap/gap.dart';
-import '../../models/expense.dart';
+import '../../utils/formatters.dart';
 import '../../models/enums.dart';
 import '../../providers/expense_provider.dart';
-import '../../providers/member_provider.dart';
+
 
 class StatisticsPage extends ConsumerWidget {
   const StatisticsPage({super.key});
@@ -15,7 +15,6 @@ class StatisticsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final monthlyExpenses = ref.watch(monthlyExpensesProvider);
-    final members = ref.watch(membersProvider);
     final monthLabel = DateFormat('yyyy年 M月', 'zh_TW').format(DateTime.now());
 
     return Scaffold(
@@ -27,7 +26,7 @@ class StatisticsPage extends ConsumerWidget {
           if (expenses.isEmpty) {
             return Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
               Icon(Icons.bar_chart_outlined, size: 64,
-                  color: theme.colorScheme.primary.withOpacity(0.3)),
+                  color: theme.colorScheme.primary.withValues(alpha:0.3)),
               const Gap(16),
               Text('本月還沒有記錄', style: theme.textTheme.titleMedium),
             ]));
@@ -99,7 +98,7 @@ class StatisticsPage extends ConsumerWidget {
                     const Gap(4),
                     Text('$icon ${cat.key}', style: theme.textTheme.bodySmall),
                     const Gap(4),
-                    Text('NT\$ ${NumberFormat('#,##0').format(cat.value)}',
+                    Text(Formatters.currency(cat.value),
                         style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600)),
                   ]);
                 }).toList()),
@@ -118,7 +117,7 @@ class StatisticsPage extends ConsumerWidget {
                       Row(children: [
                         Text(e.key, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500)),
                         const Spacer(),
-                        Text('NT\$ ${NumberFormat('#,##0').format(e.value)}',
+                        Text(Formatters.currency(e.value),
                             style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
                       ]),
                       const Gap(4),
@@ -153,12 +152,12 @@ class StatisticsPage extends ConsumerWidget {
                     const Gap(8),
                     Text('$icon ${cat.key}', style: theme.textTheme.bodyMedium),
                     const Spacer(),
-                    Text('NT\$ ${NumberFormat('#,##0').format(cat.value)}',
+                    Text(Formatters.currency(cat.value),
                         style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
                     const Gap(8),
                     Text('${(cat.value / total * 100).toStringAsFixed(0)}%',
                         style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurface.withOpacity(0.5))),
+                            color: theme.colorScheme.onSurface.withValues(alpha:0.5))),
                   ]));
                 }),
               ],

--- a/lib/services/image_storage_service.dart
+++ b/lib/services/image_storage_service.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+const _uuid = Uuid();
+
+class ImageStorageService {
+  static Future<Directory> _receiptsDir() async {
+    final appDir = await getApplicationDocumentsDirectory();
+    final dir = Directory('${appDir.path}/receipts');
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  /// Copy picked image to app storage, return the persisted path.
+  static Future<String> saveReceipt(String sourcePath) async {
+    final dir = await _receiptsDir();
+    final ext = sourcePath.contains('.') ? '.${sourcePath.split('.').last}' : '.jpg';
+    final destPath = '${dir.path}/${_uuid.v4()}$ext';
+    await File(sourcePath).copy(destPath);
+    return destPath;
+  }
+
+  /// Delete a previously saved receipt.
+  static Future<void> deleteReceipt(String path) async {
+    final file = File(path);
+    if (await file.exists()) await file.delete();
+  }
+}

--- a/lib/services/split_calculator.dart
+++ b/lib/services/split_calculator.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import '../models/split_detail.dart';
 import '../models/expense.dart';
+import '../models/settlement.dart';
 
 /// 拆帳計算核心服務
 class SplitCalculator {
@@ -85,7 +86,7 @@ class SplitCalculator {
   /// 回傳 Map<'fromId->toId', amount>，amount > 0 表示 from 欠 to
   static Map<String, double> calculateNetDebts({
     required List<Expense> expenses,
-    required List<Map<String, double>> settlements, // [{fromId: x, toId: y, amount: z}]
+    required List<Settlement> settlements,
   }) {
     // debts[fromId][toId] = 累計金額
     final Map<String, Map<String, double>> debts = {};
@@ -99,10 +100,6 @@ class SplitCalculator {
         if (!split.isParticipant) continue;
         if (split.memberId == payerId) continue;
 
-        // split.memberId 欠 payerId 的金額 = shareAmount
-        final key = '${split.memberId}->${payerId}';
-        final reverseKey = '${payerId}->${split.memberId}';
-
         debts.putIfAbsent(split.memberId, () => {});
         debts[split.memberId]!.putIfAbsent(payerId, () => 0);
         debts[split.memberId]![payerId] =
@@ -110,7 +107,16 @@ class SplitCalculator {
       }
     }
 
-    // 2. 淨額化（A 欠 B 和 B 欠 A 互相抵消）
+    // 2. 扣除結算記錄（settlement = 已還錢，減少債務）
+    for (final s in settlements) {
+      // from 已經還錢給 to → 減少 from 欠 to 的金額
+      debts.putIfAbsent(s.fromMemberId, () => {});
+      debts[s.fromMemberId]!.putIfAbsent(s.toMemberId, () => 0);
+      debts[s.fromMemberId]![s.toMemberId] =
+          debts[s.fromMemberId]![s.toMemberId]! - s.amount;
+    }
+
+    // 3. 淨額化（A 欠 B 和 B 欠 A 互相抵消）
     final Map<String, double> netDebts = {};
     final processed = <String>{};
 

--- a/lib/utils/formatters.dart
+++ b/lib/utils/formatters.dart
@@ -2,7 +2,7 @@ import 'package:intl/intl.dart';
 
 class Formatters {
   /// 新台幣格式：NT$ 1,234
-  static String currency(double amount) {
+  static String currency(num amount) {
     final formatter = NumberFormat('#,##0', 'zh_TW');
     return 'NT\$ ${formatter.format(amount.round())}';
   }

--- a/lib/widgets/member_avatar.dart
+++ b/lib/widgets/member_avatar.dart
@@ -32,7 +32,7 @@ class MemberAvatar extends StatelessWidget {
     } else {
       avatar = CircleAvatar(
         radius: size / 2,
-        backgroundColor: color.withOpacity(0.2),
+        backgroundColor: color.withValues(alpha: 0.2),
         child: Text(
           initial,
           style: TextStyle(

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.pictures.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.pictures.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- **ImageStorageService**: Copies picked images to `documents/receipts/` with UUID filenames
- **ExpenseFormPage**: Camera/gallery picker via `image_picker`, preview thumbnail with fullscreen view, replace/remove support
- **RecordsPage**: Receipt icon indicator on expense rows; tap to view fullscreen
- **iOS/macOS permissions**: Camera + photo library usage descriptions, sandbox entitlements

## Test plan
- [ ] Open expense form → tap "拍照或選擇照片" → select from gallery → see preview
- [ ] Tap fullscreen icon → see zoomable full image
- [ ] Tap X to remove photo → preview disappears
- [ ] Tap "更換照片" → pick new photo → preview updates
- [ ] Save expense with receipt → check records page shows receipt icon
- [ ] Tap receipt icon in records → fullscreen viewer opens
- [ ] Edit expense → existing receipt shown, can replace/remove
- [ ] `flutter analyze` — 0 errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)