### PR TITLE
feat(expense): description autocomplete from recent entries

### DIFF
--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -32,6 +32,17 @@ final recentExpensesProvider = StreamProvider.family<List<Expense>, int>((ref, c
   yield* isar.expenses.where().sortByDateDesc().limit(count).watch(fireImmediately: true);
 });
 
+/// 最近 200 筆不重複描述（依時間排序，最新在前）
+final recentDescriptionsProvider = FutureProvider<List<String>>((ref) async {
+  final isar = await DatabaseService.instance;
+  final expenses = await isar.expenses.where().sortByDateDesc().limit(200).findAll();
+  final seen = <String>{};
+  return expenses
+      .map((e) => e.description)
+      .where((d) => d.isNotEmpty && seen.add(d))
+      .toList();
+});
+
 final expenseNotifierProvider = AsyncNotifierProvider<ExpenseNotifier, void>(ExpenseNotifier.new);
 
 class ExpenseNotifier extends AsyncNotifier<void> {

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -38,7 +38,9 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   Map<String, TextEditingController> _pctCtrl = {};
   Map<String, TextEditingController> _customCtrl = {};
   String? _receiptPath;
+  TextEditingController? _descAutoController;
 
+  String get _descText => (_descAutoController ?? _descController).text;
   bool get _isEditing => widget.existingExpense != null;
 
   @override
@@ -130,11 +132,62 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
                 ),
               ),
               const Gap(16),
-              // 描述
-              TextFormField(controller: _descController,
-                  decoration: const InputDecoration(labelText: '描述', hintText: '例如：晚餐、加油、水費...',
-                      prefixIcon: Icon(Icons.description_outlined), border: OutlineInputBorder()),
-                  validator: (v) => (v == null || v.trim().isEmpty) ? '請輸入描述' : null),
+              // 描述（自動提示最近輸入）
+              LayoutBuilder(builder: (context, constraints) {
+                final recentDescs = ref.watch(recentDescriptionsProvider).valueOrNull ?? [];
+                return Autocomplete<String>(
+                  optionsBuilder: (textEditingValue) {
+                    if (textEditingValue.text.isEmpty) return recentDescs.take(5);
+                    final query = textEditingValue.text.toLowerCase();
+                    return recentDescs.where((d) => d.toLowerCase().contains(query)).take(8);
+                  },
+                  onSelected: (value) {
+                    _descAutoController?.text = value;
+                    _descAutoController?.selection = TextSelection.collapsed(offset: value.length);
+                  },
+                  initialValue: TextEditingValue(text: _descController.text),
+                  fieldViewBuilder: (context, controller, focusNode, onSubmitted) {
+                    _descAutoController = controller;
+                    return TextFormField(
+                      controller: controller,
+                      focusNode: focusNode,
+                      decoration: const InputDecoration(
+                        labelText: '描述',
+                        hintText: '例如：晚餐、加油、水費...',
+                        prefixIcon: Icon(Icons.description_outlined),
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (v) => (v == null || v.trim().isEmpty) ? '請輸入描述' : null,
+                    );
+                  },
+                  optionsViewBuilder: (context, onSelected, options) {
+                    return Align(
+                      alignment: Alignment.topLeft,
+                      child: Material(
+                        elevation: 4,
+                        borderRadius: BorderRadius.circular(8),
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(maxHeight: 200, maxWidth: constraints.maxWidth),
+                          child: ListView.builder(
+                            padding: EdgeInsets.zero,
+                            shrinkWrap: true,
+                            itemCount: options.length,
+                            itemBuilder: (context, index) {
+                              final option = options.elementAt(index);
+                              return ListTile(
+                                dense: true,
+                                title: Text(option),
+                                leading: const Icon(Icons.history, size: 18),
+                                onTap: () => onSelected(option),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              }),
               const Gap(16),
               // 金額
               TextFormField(controller: _amountController,
@@ -417,7 +470,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       final existing = widget.existingExpense!;
       existing
         ..date = _selectedDate
-        ..description = _descController.text.trim()
+        ..description = _descText.trim()
         ..amount = amount
         ..category = _selectedCategory
         ..isShared = _isShared
@@ -430,7 +483,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       await ref.read(expenseNotifierProvider.notifier).updateExpense(existing);
     } else {
       await ref.read(expenseNotifierProvider.notifier).addExpense(
-        date: _selectedDate, description: _descController.text.trim(),
+        date: _selectedDate, description: _descText.trim(),
         amount: amount, category: _selectedCategory, isShared: _isShared,
         splitMethod: _splitMethod, payerId: _payerId!,
         payerName: nameMap[_payerId] ?? '', splits: splits,


### PR DESCRIPTION
## Summary
- 新增 `recentDescriptionsProvider`，取得最近 200 筆不重複描述
- 描述欄位改用 `Autocomplete` widget，輸入時自動提示匹配的歷史記錄
- 空白時 focus 顯示最近 5 筆，輸入後即時過濾最多 8 筆
- 編輯模式下自動帶入既有描述

Closes #7

## Test plan
- [ ] 新增幾筆支出後，再次新增時 focus 描述欄位 → 應顯示最近輸入的描述
- [ ] 輸入部分文字 → 應過濾出匹配的歷史描述
- [ ] 點選建議項目 → 描述欄位自動填入
- [ ] 編輯既有支出 → 描述欄位應顯示原有描述

🤖 Generated with [Claude Code](https://claude.ai/code)