### PR TITLE
feat(expense): voice input with AI-powered expense parsing

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,6 +51,10 @@
 	<string>拍攝收據或發票照片以附加到支出記錄</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>從相簿選擇收據或發票照片以附加到支出記錄</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>語音記帳需要語音辨識來將語音轉為文字</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>語音記帳需要使用麥克風來錄製語音</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -13,6 +13,9 @@ import '../../providers/member_provider.dart';
 import '../../providers/expense_provider.dart';
 import '../../providers/category_provider.dart';
 import '../../services/image_storage_service.dart';
+import '../../services/expense_parser_service.dart';
+import '../../services/app_settings_service.dart';
+import '../../widgets/voice_input_button.dart';
 
 class ExpenseFormPage extends ConsumerStatefulWidget {
   final Expense? existingExpense;
@@ -85,6 +88,67 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
     super.dispose();
   }
 
+  bool _isParsingVoice = false;
+
+  Future<void> _handleVoiceResult(String text) async {
+    final categories = ref.read(categoriesProvider).valueOrNull ?? [];
+    final categoryNames = categories.map((c) => c.name).toList();
+
+    // Check API key
+    final apiKey = await AppSettingsService.geminiApiKey;
+    if (apiKey == null || apiKey.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('請先到設定頁面設定 Gemini API Key'), behavior: SnackBarBehavior.floating),
+        );
+      }
+      return;
+    }
+
+    ExpenseParserService.configure(apiKey: apiKey);
+    setState(() => _isParsingVoice = true);
+
+    try {
+      final result = await ExpenseParserService.parse(
+        text,
+        availableCategories: categoryNames,
+      );
+
+      if (!mounted) return;
+
+      // Fill form fields
+      _descAutoController?.text = result['description'] as String;
+      _amountController.text = (result['amount'] as double).toStringAsFixed(0);
+
+      final cat = result['category'] as String;
+      if (categoryNames.contains(cat)) {
+        setState(() => _selectedCategory = cat);
+      }
+
+      final dateStr = result['date'] as String?;
+      if (dateStr != null) {
+        final parsed = DateTime.tryParse(dateStr);
+        if (parsed != null) setState(() => _selectedDate = parsed);
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('已解析：${result['description']}  NT\$ ${(result['amount'] as double).toStringAsFixed(0)}'),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('AI 解析失敗：$e'), behavior: SnackBarBehavior.floating),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isParsingVoice = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -93,7 +157,26 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
     final currentUser = ref.watch(currentUserProvider);
 
     return Scaffold(
-      appBar: AppBar(title: Text(_isEditing ? '編輯支出' : '新增支出')),
+      appBar: AppBar(
+        title: Text(_isEditing ? '編輯支出' : '新增支出'),
+        actions: _isEditing ? null : [
+          if (_isParsingVoice)
+            const Padding(
+              padding: EdgeInsets.only(right: 12),
+              child: SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2)),
+            )
+          else
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: VoiceInputButton(
+                onResult: _handleVoiceResult,
+                onError: (e) => ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(e), behavior: SnackBarBehavior.floating),
+                ),
+              ),
+            ),
+        ],
+      ),
       body: members.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('錯誤：$e')),

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import '../../providers/member_provider.dart';
+import '../../services/app_settings_service.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -103,6 +104,17 @@ class SettingsPage extends ConsumerWidget {
             ]),
           )),
           const Gap(16),
+          // AI 設定
+          Card(child: Column(children: [
+            ListTile(
+              leading: const Icon(Icons.smart_toy_outlined),
+              title: const Text('Gemini API Key'),
+              subtitle: const Text('語音記帳 AI 解析所需'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => _showApiKeyDialog(context),
+            ),
+          ])),
+          const Gap(16),
           // 其他設定
           Card(child: Column(children: [
             ListTile(
@@ -158,6 +170,43 @@ class SettingsPage extends ConsumerWidget {
           if (name.isNotEmpty) {
             ref.read(memberNotifierProvider.notifier).updateMember(id, name);
             Navigator.pop(ctx);
+          }
+        }, child: const Text('儲存')),
+      ],
+    ));
+  }
+
+  void _showApiKeyDialog(BuildContext context) async {
+    final currentKey = await AppSettingsService.geminiApiKey;
+    final controller = TextEditingController(text: currentKey);
+    if (!context.mounted) return;
+    showDialog(context: context, builder: (ctx) => AlertDialog(
+      title: const Text('設定 Gemini API Key'),
+      content: Column(mainAxisSize: MainAxisSize.min, children: [
+        const Text('語音記帳需要 Google Gemini API Key 來進行 AI 解析。'),
+        const SizedBox(height: 16),
+        TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: '請輸入 API Key',
+            border: OutlineInputBorder(),
+          ),
+          obscureText: true,
+          autocorrect: false,
+          enableSuggestions: false,
+        ),
+      ]),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('取消')),
+        FilledButton(onPressed: () async {
+          final key = controller.text.trim();
+          await AppSettingsService.setGeminiApiKey(key.isEmpty ? null : key);
+          if (ctx.mounted) {
+            Navigator.pop(ctx);
+            ScaffoldMessenger.of(ctx).showSnackBar(
+              SnackBar(content: Text(key.isEmpty ? 'API Key 已清除' : 'API Key 已儲存'),
+                  behavior: SnackBarBehavior.floating),
+            );
           }
         }, child: const Text('儲存')),
       ],

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+/// 簡單的 app 設定持久化（JSON 檔案）
+class AppSettingsService {
+  static Map<String, dynamic>? _cache;
+
+  static Future<File> get _file async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/family_ledger_settings.json');
+  }
+
+  static Future<Map<String, dynamic>> _load() async {
+    if (_cache != null) return _cache!;
+    final f = await _file;
+    if (await f.exists()) {
+      _cache = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+    } else {
+      _cache = {};
+    }
+    return _cache!;
+  }
+
+  static Future<void> _save() async {
+    final f = await _file;
+    await f.writeAsString(jsonEncode(_cache ?? {}));
+  }
+
+  static Future<String?> get(String key) async {
+    final settings = await _load();
+    return settings[key] as String?;
+  }
+
+  static Future<void> set(String key, String? value) async {
+    final settings = await _load();
+    if (value == null) {
+      settings.remove(key);
+    } else {
+      settings[key] = value;
+    }
+    await _save();
+  }
+
+  // Convenience
+  static Future<String?> get geminiApiKey => get('gemini_api_key');
+  static Future<void> setGeminiApiKey(String? key) => set('gemini_api_key', key);
+}

--- a/lib/services/expense_parser_service.dart
+++ b/lib/services/expense_parser_service.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// AI 解析語音/文字為結構化記帳資料
+class ExpenseParserService {
+  static String? _apiKey;
+
+  static void configure({required String apiKey}) {
+    _apiKey = apiKey;
+  }
+
+  static bool get isConfigured => _apiKey != null && _apiKey!.isNotEmpty;
+
+  /// 解析自然語言為記帳結構
+  /// 回傳 Map: {description, amount, category, date?}
+  static Future<Map<String, dynamic>> parse(
+    String text, {
+    required List<String> availableCategories,
+  }) async {
+    final apiKey = _apiKey;
+    if (apiKey == null || apiKey.isEmpty) {
+      throw Exception('尚未設定 AI API Key，請至設定頁面設定');
+    }
+
+    final now = DateTime.now();
+    final today = '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+
+    final prompt = '''你是一個記帳助手。請從以下語音輸入中提取記帳資訊，回傳 JSON 格式。
+
+可用類別：${availableCategories.join('、')}
+
+規則：
+- amount 必須是正數數字（不含貨幣符號）
+- category 必須從可用類別中選擇最接近的一個
+- date 格式為 YYYY-MM-DD，如果沒有提到日期則用今天 $today
+- description 是簡短的支出描述
+- 如果無法解析金額，amount 設為 0
+
+只回傳 JSON，不要其他文字：
+{"description": "...", "amount": 數字, "category": "...", "date": "YYYY-MM-DD"}
+
+語音輸入：「$text」''';
+
+    final url = Uri.parse(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$apiKey',
+    );
+
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'contents': [
+          {
+            'parts': [
+              {'text': prompt}
+            ]
+          }
+        ],
+        'generationConfig': {
+          'temperature': 0.1,
+          'responseMimeType': 'application/json',
+        },
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('AI 解析失敗 (${response.statusCode})：${response.body}');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final candidates = body['candidates'] as List?;
+    if (candidates == null || candidates.isEmpty) {
+      throw Exception('AI 無法解析此內容');
+    }
+
+    final content = candidates[0]['content']['parts'][0]['text'] as String;
+    // Strip markdown code fences if present
+    final cleaned = content
+        .replaceAll(RegExp(r'^```json\s*', multiLine: true), '')
+        .replaceAll(RegExp(r'^```\s*$', multiLine: true), '')
+        .trim();
+
+    final parsed = jsonDecode(cleaned) as Map<String, dynamic>;
+
+    // Validate and sanitize
+    return {
+      'description': (parsed['description'] as String?)?.trim() ?? text,
+      'amount': (parsed['amount'] is num) ? (parsed['amount'] as num).toDouble() : 0.0,
+      'category': availableCategories.contains(parsed['category'])
+          ? parsed['category']
+          : availableCategories.first,
+      'date': parsed['date'] as String? ?? today,
+    };
+  }
+}

--- a/lib/widgets/voice_input_button.dart
+++ b/lib/widgets/voice_input_button.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+/// 語音輸入按鈕 — 按住說話，放開停止
+class VoiceInputButton extends StatefulWidget {
+  final void Function(String text) onResult;
+  final void Function(String error)? onError;
+
+  const VoiceInputButton({
+    super.key,
+    required this.onResult,
+    this.onError,
+  });
+
+  @override
+  State<VoiceInputButton> createState() => _VoiceInputButtonState();
+}
+
+class _VoiceInputButtonState extends State<VoiceInputButton>
+    with SingleTickerProviderStateMixin {
+  final _speech = stt.SpeechToText();
+  bool _isListening = false;
+  bool _isAvailable = false;
+  String _currentText = '';
+  late AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+    _initSpeech();
+  }
+
+  Future<void> _initSpeech() async {
+    _isAvailable = await _speech.initialize(
+      onError: (error) {
+        setState(() => _isListening = false);
+        _pulseController.stop();
+        if (error.errorMsg == 'error_no_match' && _currentText.isNotEmpty) {
+          widget.onResult(_currentText);
+        } else if (error.errorMsg != 'error_no_match') {
+          widget.onError?.call('語音辨識錯誤：${error.errorMsg}');
+        }
+      },
+    );
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _startListening() async {
+    if (!_isAvailable) {
+      widget.onError?.call('語音辨識不可用');
+      return;
+    }
+
+    _currentText = '';
+    setState(() => _isListening = true);
+    _pulseController.repeat(reverse: true);
+
+    await _speech.listen(
+      onResult: (result) {
+        _currentText = result.recognizedWords;
+        if (result.finalResult && _currentText.isNotEmpty) {
+          _stopListening();
+          widget.onResult(_currentText);
+        }
+      },
+      localeId: 'zh_TW',
+      listenMode: stt.ListenMode.dictation,
+    );
+  }
+
+  Future<void> _stopListening() async {
+    await _speech.stop();
+    _pulseController.stop();
+    _pulseController.reset();
+    if (mounted) setState(() => _isListening = false);
+  }
+
+  @override
+  void dispose() {
+    _speech.stop();
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AnimatedBuilder(
+      animation: _pulseController,
+      builder: (context, child) {
+        final scale = _isListening ? 1.0 + _pulseController.value * 0.15 : 1.0;
+        return Transform.scale(
+          scale: scale,
+          child: FloatingActionButton.small(
+            heroTag: 'voice_input',
+            onPressed: _isListening ? _stopListening : _startListening,
+            backgroundColor: _isListening
+                ? theme.colorScheme.error
+                : theme.colorScheme.primaryContainer,
+            foregroundColor: _isListening
+                ? theme.colorScheme.onError
+                : theme.colorScheme.onPrimaryContainer,
+            child: Icon(_isListening ? Icons.stop : Icons.mic),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,7 +497,7 @@ packages:
     source: hosted
     version: "1.0.2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -832,6 +832,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -997,6 +1005,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: "57fef1d41bdebe298e84842c89bb4ac91f31cdbec7830c8cb1fc6b91d03abd42"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  speech_to_text_macos:
+    dependency: transitive
+    description:
+      name: speech_to_text_macos
+      sha256: e685750f7542fcaa087a5396ee471e727ec648bf681f4da83c84d086322173f6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: a1935847704e41ee468aad83181ddd2423d0833abe55d769c59afca07adb5114
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   sqflite:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
   csv: ^6.0.0
   share_plus: ^9.0.0
 
+  # 語音 / AI
+  speech_to_text: ^6.6.0
+  http: ^1.2.1
+
   # 工具
   uuid: ^4.3.3
   collection: ^1.18.0


### PR DESCRIPTION
## Summary
- 新增語音記帳功能：點擊麥克風按鈕 → 語音輸入 → AI 自動解析為記帳資料
- 使用 speech_to_text 進行語音轉文字（繁體中文）
- 使用 Gemini API 將自然語言解析為結構化記帳資料（描述、金額、類別、日期）
- 設定頁面新增 Gemini API Key 設定（obscured 輸入，sandbox 存儲）
- iOS/macOS 已加入麥克風、語音辨識、網路權限

## 安全措施
- API Key 存儲在 app documents 目錄（OS sandbox 保護）
- 輸入欄位使用 obscureText
- API Key 僅透過 HTTPS 傳送至 Gemini API，不會 log 或暴露

Closes #11

## Test plan
- [ ] 設定頁面 → 設定 Gemini API Key → 確認儲存成功
- [ ] 新增支出 → 點擊麥克風 → 說「午餐一百二十元」→ 確認自動填入描述、金額、類別
- [ ] 未設定 API Key 時點擊語音 → 應提示前往設定
- [ ] 編輯支出模式 → 不應顯示語音按鈕

🤖 Generated with [Claude Code](https://claude.ai/code)