### PR TITLE
feat(settings): category management page

### DIFF
--- a/lib/providers/category_provider.dart
+++ b/lib/providers/category_provider.dart
@@ -11,3 +11,72 @@ final categoriesProvider = StreamProvider<List<Category>>((ref) async* {
       .sortBySortOrder()
       .watch(fireImmediately: true);
 });
+
+/// 所有類別（含停用，管理頁面用）
+final allCategoriesProvider = StreamProvider<List<Category>>((ref) async* {
+  final isar = await DatabaseService.instance;
+  yield* isar.categorys
+      .where()
+      .sortBySortOrder()
+      .watch(fireImmediately: true);
+});
+
+final categoryNotifierProvider =
+    AsyncNotifierProvider<CategoryNotifier, void>(CategoryNotifier.new);
+
+class CategoryNotifier extends AsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> addCategory({
+    required String name,
+    required String icon,
+  }) async {
+    final isar = await DatabaseService.instance;
+    final groupId = await DatabaseService.getPrimaryGroupId();
+    if (groupId == null) return;
+    // Get max sort order
+    final all = await isar.categorys.where().sortBySortOrderDesc().findFirst();
+    final maxOrder = all?.sortOrder ?? -1;
+    final cat = Category()
+      ..groupId = groupId
+      ..name = name
+      ..icon = icon
+      ..sortOrder = maxOrder + 1
+      ..isDefault = false
+      ..isActive = true;
+    await isar.writeTxn(() async {
+      await isar.categorys.put(cat);
+    });
+  }
+
+  Future<void> updateCategory(Category category) async {
+    final isar = await DatabaseService.instance;
+    await isar.writeTxn(() async {
+      await isar.categorys.put(category);
+    });
+  }
+
+  Future<void> toggleActive(Category category) async {
+    category.isActive = !category.isActive;
+    await updateCategory(category);
+  }
+
+  Future<void> deleteCategory(Category category) async {
+    if (category.isDefault) return; // 預設類別不可刪除
+    final isar = await DatabaseService.instance;
+    await isar.writeTxn(() async {
+      await isar.categorys.delete(category.isarId);
+    });
+  }
+
+  Future<void> reorder(List<Category> categories) async {
+    final isar = await DatabaseService.instance;
+    await isar.writeTxn(() async {
+      for (var i = 0; i < categories.length; i++) {
+        categories[i].sortOrder = i;
+        await isar.categorys.put(categories[i]);
+      }
+    });
+  }
+}

--- a/lib/screens/settings/category_management_page.dart
+++ b/lib/screens/settings/category_management_page.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import '../../models/category.dart';
+import '../../providers/category_provider.dart';
+
+class CategoryManagementPage extends ConsumerWidget {
+  const CategoryManagementPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final allCategories = ref.watch(allCategoriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('類別管理'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: '新增類別',
+            onPressed: () => _showEditDialog(context, ref, null),
+          ),
+        ],
+      ),
+      body: allCategories.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('錯誤：$e')),
+        data: (categories) {
+          if (categories.isEmpty) {
+            return const Center(child: Text('沒有類別'));
+          }
+          return ReorderableListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: categories.length,
+            onReorder: (oldIndex, newIndex) {
+              final reordered = List<Category>.from(categories);
+              if (newIndex > oldIndex) newIndex--;
+              final item = reordered.removeAt(oldIndex);
+              reordered.insert(newIndex, item);
+              ref.read(categoryNotifierProvider.notifier).reorder(reordered);
+            },
+            itemBuilder: (context, index) {
+              final cat = categories[index];
+              return Card(
+                key: ValueKey(cat.isarId),
+                child: ListTile(
+                  leading: Text(cat.icon, style: const TextStyle(fontSize: 28)),
+                  title: Text(cat.name),
+                  subtitle: Row(children: [
+                    if (cat.isDefault)
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primaryContainer,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text('預設', style: TextStyle(
+                          fontSize: 11, color: theme.colorScheme.onPrimaryContainer)),
+                      ),
+                    if (cat.isDefault) const Gap(6),
+                    Text(cat.isActive ? '啟用中' : '已停用',
+                        style: TextStyle(
+                          color: cat.isActive
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.error,
+                          fontSize: 12,
+                        )),
+                  ]),
+                  trailing: Row(mainAxisSize: MainAxisSize.min, children: [
+                    // Toggle active
+                    Switch(
+                      value: cat.isActive,
+                      onChanged: (_) => ref.read(categoryNotifierProvider.notifier).toggleActive(cat),
+                    ),
+                    // Edit
+                    IconButton(
+                      icon: const Icon(Icons.edit_outlined, size: 20),
+                      onPressed: () => _showEditDialog(context, ref, cat),
+                    ),
+                    // Delete (non-default only)
+                    if (!cat.isDefault)
+                      IconButton(
+                        icon: Icon(Icons.delete_outline, size: 20,
+                            color: theme.colorScheme.error.withValues(alpha: 0.7)),
+                        onPressed: () => _confirmDelete(context, ref, cat),
+                      ),
+                    // Drag handle
+                    const Icon(Icons.drag_handle, size: 20),
+                  ]),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _showEditDialog(BuildContext context, WidgetRef ref, Category? existing) {
+    final nameController = TextEditingController(text: existing?.name ?? '');
+    final iconController = TextEditingController(text: existing?.icon ?? '');
+    final isEdit = existing != null;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(isEdit ? '編輯類別' : '新增類別'),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          TextField(
+            controller: iconController,
+            decoration: const InputDecoration(
+              labelText: '圖示（Emoji）',
+              hintText: '例如：🍜',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const Gap(12),
+          TextField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              labelText: '類別名稱',
+              hintText: '例如：餐飲',
+              border: OutlineInputBorder(),
+            ),
+            autofocus: true,
+          ),
+        ]),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('取消')),
+          FilledButton(
+            onPressed: () {
+              final name = nameController.text.trim();
+              final icon = iconController.text.trim();
+              if (name.isEmpty) return;
+              if (isEdit) {
+                existing!
+                  ..name = name
+                  ..icon = icon.isEmpty ? '📌' : icon;
+                ref.read(categoryNotifierProvider.notifier).updateCategory(existing);
+              } else {
+                ref.read(categoryNotifierProvider.notifier).addCategory(
+                  name: name,
+                  icon: icon.isEmpty ? '📌' : icon,
+                );
+              }
+              Navigator.pop(ctx);
+            },
+            child: Text(isEdit ? '儲存' : '新增'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context, WidgetRef ref, Category cat) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('刪除類別'),
+        content: Text('確定要刪除「${cat.icon} ${cat.name}」嗎？已使用此類別的記錄不會受影響。'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('取消')),
+          FilledButton(
+            onPressed: () {
+              ref.read(categoryNotifierProvider.notifier).deleteCategory(cat);
+              Navigator.pop(ctx);
+            },
+            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
+            child: const Text('刪除'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
+import 'category_management_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -103,6 +104,18 @@ class SettingsPage extends ConsumerWidget {
               ),
             ]),
           )),
+          const Gap(16),
+          // 類別管理
+          Card(child: Column(children: [
+            ListTile(
+              leading: const Icon(Icons.category_outlined),
+              title: const Text('類別管理'),
+              subtitle: const Text('新增、編輯、排序支出類別'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.push(context,
+                  MaterialPageRoute(builder: (_) => const CategoryManagementPage())),
+            ),
+          ])),
           const Gap(16),
           // AI 設定
           Card(child: Column(children: [


### PR DESCRIPTION
## Summary
- 設定頁面新增「類別管理」入口
- 類別管理頁面支援：新增、編輯名稱/圖示、拖曳排序、啟用/停用切換、刪除（非預設類別）
- 預設類別標示「預設」徽章，不可刪除

Closes #9

## Test plan
- [ ] 設定 → 類別管理 → 可看到所有預設類別
- [ ] 點 + 新增自訂類別 → 輸入 emoji + 名稱 → 確認出現在列表
- [ ] 編輯類別名稱和圖示 → 確認更新
- [ ] 拖曳排序 → 確認順序保存
- [ ] 停用類別 → 確認記帳時不再顯示
- [ ] 刪除自訂類別 → 確認刪除成功
- [ ] 預設類別不顯示刪除按鈕

🤖 Generated with [Claude Code](https://claude.ai/code)