### PR TITLE
feat(records): duplicate expense action

### DIFF
--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -20,7 +20,8 @@ import '../../widgets/calculator_sheet.dart';
 
 class ExpenseFormPage extends ConsumerStatefulWidget {
   final Expense? existingExpense;
-  const ExpenseFormPage({super.key, this.existingExpense});
+  final Expense? duplicateFrom;
+  const ExpenseFormPage({super.key, this.existingExpense, this.duplicateFrom});
   @override
   ConsumerState<ExpenseFormPage> createState() => _ExpenseFormPageState();
 }
@@ -50,17 +51,18 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   @override
   void initState() {
     super.initState();
-    final e = widget.existingExpense;
+    final e = widget.existingExpense ?? widget.duplicateFrom;
     if (e != null) {
+      final isDuplicate = widget.duplicateFrom != null;
       _descController.text = e.description;
       _amountController.text = e.amount.toStringAsFixed(0);
       _noteController.text = e.note ?? '';
-      _selectedDate = e.date;
+      _selectedDate = isDuplicate ? DateTime.now() : e.date;
       _selectedCategory = e.category;
       _isShared = e.isShared;
       _splitMethod = e.splitMethod;
       _payerId = e.payerId;
-      _receiptPath = e.receiptPath;
+      _receiptPath = isDuplicate ? null : e.receiptPath;
       _participantIds = e.splits.where((s) => s.isParticipant).map((s) => s.memberId).toSet();
       if (_splitMethod == SplitMethod.percentage) {
         final total = e.amount;

--- a/lib/screens/records/records_page.dart
+++ b/lib/screens/records/records_page.dart
@@ -93,6 +93,15 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                           label: '編輯',
                           borderRadius: BorderRadius.circular(12),
                         ),
+                        SlidableAction(
+                          onPressed: (_) => Navigator.push(context,
+                              MaterialPageRoute(builder: (_) => ExpenseFormPage(duplicateFrom: e))),
+                          backgroundColor: theme.colorScheme.tertiary,
+                          foregroundColor: theme.colorScheme.onTertiary,
+                          icon: Icons.copy,
+                          label: '複製',
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                       ]),
                       endActionPane: ActionPane(motion: const DrawerMotion(), children: [
                         SlidableAction(


### PR DESCRIPTION
## Summary
- 記錄頁面支出項目向右滑動新增「複製」按鈕
- 點擊後以該筆記錄為範本開啟新增表單，預填描述、金額、類別、付款人、分帳設定
- 日期自動設為今天，不複製收據照片

Closes #12

## Test plan
- [ ] 記錄頁面 → 向右滑動任一筆支出 → 應顯示「編輯」和「複製」兩個按鈕
- [ ] 點擊「複製」→ 開啟新增表單，描述/金額/類別等已填入
- [ ] 確認日期為今天（非原始記錄日期）
- [ ] 確認收據照片未被複製
- [ ] 送出後確認為新增記錄（非修改原記錄）

🤖 Generated with [Claude Code](https://claude.ai/code)