### PR TITLE
feat(settings): theme switching with 6 color themes

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'providers/theme_provider.dart';
 import 'screens/home/home_page.dart';
 import 'screens/split/split_overview_page.dart';
 import 'screens/records/records_page.dart';
@@ -7,25 +9,26 @@ import 'screens/settings/settings_page.dart';
 import 'screens/expense/expense_form_page.dart';
 
 /// 家計本 App 主體
-class FamilyLedgerApp extends StatelessWidget {
+class FamilyLedgerApp extends ConsumerWidget {
   const FamilyLedgerApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(themeSettingsProvider);
     return MaterialApp(
       title: '家計本',
       debugShowCheckedModeBanner: false,
-      theme: _buildLightTheme(),
-      darkTheme: _buildDarkTheme(),
-      themeMode: ThemeMode.system,
+      theme: _buildTheme(settings.theme.lightSeed, Brightness.light),
+      darkTheme: _buildTheme(settings.theme.darkSeed, Brightness.dark),
+      themeMode: settings.mode,
       home: const MainShell(),
     );
   }
 
-  ThemeData _buildLightTheme() {
+  ThemeData _buildTheme(Color seedColor, Brightness brightness) {
     final colorScheme = ColorScheme.fromSeed(
-      seedColor: const Color(0xFF2E7D32),
-      brightness: Brightness.light,
+      seedColor: seedColor,
+      brightness: brightness,
     );
     return ThemeData(
       useMaterial3: true,
@@ -45,28 +48,6 @@ class FamilyLedgerApp extends StatelessWidget {
         backgroundColor: colorScheme.primary,
         foregroundColor: colorScheme.onPrimary,
         elevation: 4,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      ),
-    );
-  }
-
-  ThemeData _buildDarkTheme() {
-    final colorScheme = ColorScheme.fromSeed(
-      seedColor: const Color(0xFF66BB6A),
-      brightness: Brightness.dark,
-    );
-    return ThemeData(
-      useMaterial3: true,
-      colorScheme: colorScheme,
-      fontFamily: 'NotoSansTC',
-      appBarTheme: AppBarTheme(
-        centerTitle: true,
-        backgroundColor: colorScheme.surface,
-        foregroundColor: colorScheme.onSurface,
-        elevation: 0,
-      ),
-      cardTheme: CardThemeData(
-        elevation: 1,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       ),
     );

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/app_settings_service.dart';
+
+/// 可用主題定義
+enum AppTheme {
+  green('森林綠', Color(0xFF2E7D32), Color(0xFF66BB6A)),
+  blue('海洋藍', Color(0xFF1565C0), Color(0xFF42A5F5)),
+  purple('薰衣草紫', Color(0xFF6A1B9A), Color(0xFFAB47BC)),
+  orange('暖陽橘', Color(0xFFE65100), Color(0xFFFF7043)),
+  pink('玫瑰粉', Color(0xFFAD1457), Color(0xFFEC407A)),
+  teal('薄荷青', Color(0xFF00695C), Color(0xFF26A69A));
+
+  final String label;
+  final Color lightSeed;
+  final Color darkSeed;
+
+  const AppTheme(this.label, this.lightSeed, this.darkSeed);
+}
+
+/// 主題模式 + 配色組合
+class ThemeSettings {
+  final ThemeMode mode;
+  final AppTheme theme;
+
+  const ThemeSettings({this.mode = ThemeMode.system, this.theme = AppTheme.green});
+}
+
+final themeSettingsProvider =
+    StateNotifierProvider<ThemeSettingsNotifier, ThemeSettings>(
+        (ref) => ThemeSettingsNotifier());
+
+class ThemeSettingsNotifier extends StateNotifier<ThemeSettings> {
+  ThemeSettingsNotifier() : super(const ThemeSettings()) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final modeStr = await AppSettingsService.get('theme_mode');
+    final themeStr = await AppSettingsService.get('theme_color');
+
+    final mode = switch (modeStr) {
+      'light' => ThemeMode.light,
+      'dark' => ThemeMode.dark,
+      _ => ThemeMode.system,
+    };
+
+    final theme = AppTheme.values.firstWhere(
+      (t) => t.name == themeStr,
+      orElse: () => AppTheme.green,
+    );
+
+    state = ThemeSettings(mode: mode, theme: theme);
+  }
+
+  Future<void> setMode(ThemeMode mode) async {
+    state = ThemeSettings(mode: mode, theme: state.theme);
+    final str = switch (mode) {
+      ThemeMode.light => 'light',
+      ThemeMode.dark => 'dark',
+      _ => 'system',
+    };
+    await AppSettingsService.set('theme_mode', str);
+  }
+
+  Future<void> setTheme(AppTheme theme) async {
+    state = ThemeSettings(mode: state.mode, theme: theme);
+    await AppSettingsService.set('theme_color', theme.name);
+  }
+}

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
+import '../../providers/theme_provider.dart';
 import 'category_management_page.dart';
 
 class SettingsPage extends ConsumerWidget {
@@ -102,6 +103,40 @@ class SettingsPage extends ConsumerWidget {
                   )).toList());
                 },
               ),
+            ]),
+          )),
+          const Gap(16),
+          // 主題設定
+          Card(child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              Row(children: [
+                Icon(Icons.palette_outlined, color: theme.colorScheme.primary, size: 20),
+                const Gap(8),
+                Text('主題', style: theme.textTheme.titleMedium),
+              ]),
+              const Gap(12),
+              // 模式切換
+              SegmentedButton<ThemeMode>(
+                segments: const [
+                  ButtonSegment(value: ThemeMode.system, label: Text('跟隨系統'), icon: Icon(Icons.brightness_auto)),
+                  ButtonSegment(value: ThemeMode.light, label: Text('淺色'), icon: Icon(Icons.light_mode)),
+                  ButtonSegment(value: ThemeMode.dark, label: Text('深色'), icon: Icon(Icons.dark_mode)),
+                ],
+                selected: {ref.watch(themeSettingsProvider).mode},
+                onSelectionChanged: (s) => ref.read(themeSettingsProvider.notifier).setMode(s.first),
+              ),
+              const Gap(16),
+              // 配色選擇
+              Wrap(spacing: 8, runSpacing: 8, children: AppTheme.values.map((t) {
+                final isSelected = ref.watch(themeSettingsProvider).theme == t;
+                return ChoiceChip(
+                  label: Text(t.label),
+                  selected: isSelected,
+                  avatar: CircleAvatar(backgroundColor: t.lightSeed, radius: 10),
+                  onSelected: (_) => ref.read(themeSettingsProvider.notifier).setTheme(t),
+                );
+              }).toList()),
             ]),
           )),
           const Gap(16),


### PR DESCRIPTION
## Summary
- 設定頁面新增主題設定區塊
- 支援 3 種模式：跟隨系統 / 淺色 / 深色（SegmentedButton 切換）
- 支援 6 種配色主題：森林綠、海洋藍、薰衣草紫、暖陽橘、玫瑰粉、薄荷青（ChoiceChip 選擇）
- 設定持久化，重啟 app 後保留

Closes #13

## Test plan
- [ ] 設定 → 主題 → 切換淺色/深色/跟隨系統 → 確認即時生效
- [ ] 選擇不同配色 → 確認所有頁面配色一致變更
- [ ] 重啟 app → 確認主題設定保留

🤖 Generated with [Claude Code](https://claude.ai/code)