### PR TITLE
feat(settings): add activity log for operation audit trail

### DIFF
--- a/lib/models/activity_log.dart
+++ b/lib/models/activity_log.dart
@@ -1,0 +1,30 @@
+import 'package:isar/isar.dart';
+
+part 'activity_log.g.dart';
+
+/// 操作日誌
+@collection
+class ActivityLog {
+  Id isarId = Isar.autoIncrement;
+
+  /// 操作類型：expense_add, expense_edit, expense_delete,
+  ///          settlement_add, settlement_delete, member_add, member_edit, etc.
+  @Index()
+  late String action;
+
+  /// 操作者名稱
+  late String actorName;
+
+  /// 操作者 ID
+  late String actorId;
+
+  /// 描述（人類可讀）
+  late String description;
+
+  /// 相關實體 ID（可選）
+  String? entityId;
+
+  /// 操作時間
+  @Index()
+  late DateTime createdAt;
+}

--- a/lib/providers/activity_log_provider.dart
+++ b/lib/providers/activity_log_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar/isar.dart';
+import '../models/activity_log.dart';
+import '../services/database_service.dart';
+
+/// 最近 100 筆操作日誌
+final activityLogsProvider = StreamProvider<List<ActivityLog>>((ref) async* {
+  final isar = await DatabaseService.instance;
+  yield* isar.activityLogs
+      .where()
+      .sortByCreatedAtDesc()
+      .limit(100)
+      .watch(fireImmediately: true);
+});
+
+/// 記錄操作日誌
+class ActivityLogger {
+  static Future<void> log({
+    required String action,
+    required String actorName,
+    required String actorId,
+    required String description,
+    String? entityId,
+  }) async {
+    final isar = await DatabaseService.instance;
+    final entry = ActivityLog()
+      ..action = action
+      ..actorName = actorName
+      ..actorId = actorId
+      ..description = description
+      ..entityId = entityId
+      ..createdAt = DateTime.now();
+    await isar.writeTxn(() async {
+      await isar.activityLogs.put(entry);
+    });
+  }
+}

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -7,6 +7,7 @@ import '../models/split_detail.dart';
 import '../services/database_service.dart';
 import '../services/image_storage_service.dart';
 import 'balance_provider.dart';
+import 'activity_log_provider.dart';
 
 const _uuid = Uuid();
 
@@ -87,6 +88,12 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     await isar.writeTxn(() async {
       await isar.expenses.put(expense);
     });
+    await ActivityLogger.log(
+      action: 'expense_add',
+      actorName: payerName, actorId: payerId,
+      description: '$payerName 新增支出「$description」NT\$ ${amount.toStringAsFixed(0)}',
+      entityId: expense.id,
+    );
     if (isShared) {
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }
@@ -98,6 +105,12 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     await isar.writeTxn(() async {
       await isar.expenses.put(expense);
     });
+    await ActivityLogger.log(
+      action: 'expense_edit',
+      actorName: expense.payerName, actorId: expense.payerId,
+      description: '${expense.payerName} 編輯支出「${expense.description}」',
+      entityId: expense.id,
+    );
     if (expense.isShared) {
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }
@@ -113,6 +126,12 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     if (receiptPath != null) {
       await ImageStorageService.deleteReceipt(receiptPath);
     }
+    await ActivityLogger.log(
+      action: 'expense_delete',
+      actorName: expense.payerName, actorId: expense.payerId,
+      description: '刪除支出「${expense.description}」NT\$ ${expense.amount.toStringAsFixed(0)}',
+      entityId: expense.id,
+    );
     if (wasShared) {
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }

--- a/lib/providers/settlement_provider.dart
+++ b/lib/providers/settlement_provider.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import '../models/settlement.dart';
 import '../services/database_service.dart';
 import 'balance_provider.dart';
+import 'activity_log_provider.dart';
 
 const _uuid = Uuid();
 
@@ -45,6 +46,12 @@ class SettlementNotifier extends AsyncNotifier<void> {
     await isar.writeTxn(() async {
       await isar.settlements.put(settlement);
     });
+    await ActivityLogger.log(
+      action: 'settlement_add',
+      actorName: fromMemberName, actorId: fromMemberId,
+      description: '$fromMemberName 付款給 $toMemberName NT\$ ${amount.toStringAsFixed(0)}',
+      entityId: settlement.id,
+    );
     await ref.read(balanceNotifierProvider.notifier).recalculate();
   }
 
@@ -53,6 +60,12 @@ class SettlementNotifier extends AsyncNotifier<void> {
     await isar.writeTxn(() async {
       await isar.settlements.delete(settlement.isarId);
     });
+    await ActivityLogger.log(
+      action: 'settlement_delete',
+      actorName: settlement.fromMemberName, actorId: settlement.fromMemberId,
+      description: '刪除付款記錄：${settlement.fromMemberName} → ${settlement.toMemberName} NT\$ ${settlement.amount.toStringAsFixed(0)}',
+      entityId: settlement.id,
+    );
     await ref.read(balanceNotifierProvider.notifier).recalculate();
   }
 }

--- a/lib/screens/settings/activity_log_page.dart
+++ b/lib/screens/settings/activity_log_page.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../providers/activity_log_provider.dart';
+
+class ActivityLogPage extends ConsumerWidget {
+  const ActivityLogPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final logs = ref.watch(activityLogsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('操作日誌')),
+      body: logs.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (entries) {
+          if (entries.isEmpty) {
+            return Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
+              Icon(Icons.history, size: 64,
+                  color: theme.colorScheme.primary.withValues(alpha: 0.3)),
+              const SizedBox(height: 16),
+              Text('尚無操作記錄', style: theme.textTheme.titleMedium),
+            ]));
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: entries.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final log = entries[index];
+              final icon = switch (log.action) {
+                'expense_add' => Icons.add_circle_outline,
+                'expense_edit' => Icons.edit_outlined,
+                'expense_delete' => Icons.delete_outline,
+                'settlement_add' => Icons.payments_outlined,
+                'settlement_delete' => Icons.money_off,
+                'member_add' => Icons.person_add_outlined,
+                'member_edit' => Icons.person_outline,
+                _ => Icons.info_outline,
+              };
+              final color = log.action.contains('delete')
+                  ? theme.colorScheme.error
+                  : theme.colorScheme.primary;
+
+              return ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  backgroundColor: color.withValues(alpha: 0.1),
+                  foregroundColor: color,
+                  child: Icon(icon, size: 20),
+                ),
+                title: Text(log.description, style: theme.textTheme.bodyMedium),
+                subtitle: Text(
+                  DateFormat('MM/dd HH:mm', 'zh_TW').format(log.createdAt),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -5,6 +5,7 @@ import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
 import '../../providers/theme_provider.dart';
 import 'category_management_page.dart';
+import 'activity_log_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -160,6 +161,18 @@ class SettingsPage extends ConsumerWidget {
               subtitle: const Text('語音記帳 AI 解析所需'),
               trailing: const Icon(Icons.chevron_right),
               onTap: () => _showApiKeyDialog(context),
+            ),
+          ])),
+          const Gap(16),
+          // 操作日誌
+          Card(child: Column(children: [
+            ListTile(
+              leading: const Icon(Icons.history),
+              title: const Text('操作日誌'),
+              subtitle: const Text('查看所有成員的操作記錄'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.push(context,
+                  MaterialPageRoute(builder: (_) => const ActivityLogPage())),
             ),
           ])),
           const Gap(16),

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -6,6 +6,7 @@ import '../models/expense.dart';
 import '../models/balance.dart';
 import '../models/category.dart';
 import '../models/settlement.dart';
+import '../models/activity_log.dart';
 import '../models/enums.dart';
 import 'package:uuid/uuid.dart';
 
@@ -32,6 +33,7 @@ class DatabaseService {
         BalanceSchema,
         CategorySchema,
         SettlementSchema,
+        ActivityLogSchema,
       ],
       directory: dir.path,
       name: 'family_ledger',


### PR DESCRIPTION
## Summary
- Add `ActivityLog` Isar collection with action, actor, description, and timestamp fields
- Add `ActivityLogger.log()` utility for recording operations across providers
- Integrate logging into expense add/edit/delete and settlement add/delete
- Add activity log page in Settings with icon-coded entries and timestamps

Closes #17

## Test plan
- [ ] Open Settings → 操作日誌 shows empty state
- [ ] Add/edit/delete an expense → log entries appear
- [ ] Add/delete a settlement → log entries appear
- [ ] Verify timestamps are correct in zh_TW format

🤖 Generated with [Claude Code](https://claude.com/claude-code)