### PR TITLE
feat(notification): add in-app notification bell with unread badge

### DIFF
--- a/lib/models/app_notification.dart
+++ b/lib/models/app_notification.dart
@@ -1,0 +1,34 @@
+import 'package:isar/isar.dart';
+
+part 'app_notification.g.dart';
+
+/// 應用內通知
+@collection
+class AppNotification {
+  Id isarId = Isar.autoIncrement;
+
+  /// 通知類型：split_expense, settlement
+  @Index()
+  late String type;
+
+  /// 通知標題
+  late String title;
+
+  /// 通知內容
+  late String body;
+
+  /// 相關實體 ID（expense / settlement）
+  String? entityId;
+
+  /// 接收者成員 ID
+  @Index()
+  late String recipientId;
+
+  /// 是否已讀
+  @Index()
+  late bool isRead;
+
+  /// 建立時間
+  @Index()
+  late DateTime createdAt;
+}

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -8,6 +8,7 @@ import '../services/database_service.dart';
 import '../services/image_storage_service.dart';
 import 'balance_provider.dart';
 import 'activity_log_provider.dart';
+import 'notification_provider.dart';
 
 const _uuid = Uuid();
 
@@ -95,6 +96,17 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       entityId: expense.id,
     );
     if (isShared) {
+      await NotificationService.notifySplitExpense(
+        expenseId: expense.id,
+        payerName: payerName,
+        description: description,
+        amount: amount,
+        participants: splits
+            .where((s) => s.isParticipant)
+            .map((s) => (memberId: s.memberId, memberName: s.memberName, shareAmount: s.shareAmount))
+            .toList(),
+        payerId: payerId,
+      );
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }
   }

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar/isar.dart';
+import '../models/app_notification.dart';
+import '../services/database_service.dart';
+
+/// 目前使用者的未讀通知數
+final unreadNotificationCountProvider = StreamProvider<int>((ref) async* {
+  final isar = await DatabaseService.instance;
+  final user = await DatabaseService.getCurrentUser();
+  if (user == null) {
+    yield 0;
+    return;
+  }
+  yield* isar.appNotifications
+      .filter()
+      .recipientIdEqualTo(user.id)
+      .isReadEqualTo(false)
+      .watch(fireImmediately: true)
+      .map((list) => list.length);
+});
+
+/// 目前使用者的所有通知（最新在前）
+final userNotificationsProvider = StreamProvider<List<AppNotification>>((ref) async* {
+  final isar = await DatabaseService.instance;
+  final user = await DatabaseService.getCurrentUser();
+  if (user == null) {
+    yield [];
+    return;
+  }
+  yield* isar.appNotifications
+      .filter()
+      .recipientIdEqualTo(user.id)
+      .sortByCreatedAtDesc()
+      .limit(50)
+      .watch(fireImmediately: true);
+});
+
+/// 通知操作
+class NotificationService {
+  /// 為分攤費用的參與者建立通知
+  static Future<void> notifySplitExpense({
+    required String expenseId,
+    required String payerName,
+    required String description,
+    required double amount,
+    required List<({String memberId, String memberName, double shareAmount})> participants,
+    required String payerId,
+  }) async {
+    final isar = await DatabaseService.instance;
+    final now = DateTime.now();
+    final notifications = <AppNotification>[];
+
+    for (final p in participants) {
+      // 不通知付款人自己
+      if (p.memberId == payerId) continue;
+      notifications.add(AppNotification()
+        ..type = 'split_expense'
+        ..title = '新的分攤費用'
+        ..body = '$payerName 新增了「$description」NT\$ ${amount.toStringAsFixed(0)}，你需分攤 NT\$ ${p.shareAmount.toStringAsFixed(0)}'
+        ..entityId = expenseId
+        ..recipientId = p.memberId
+        ..isRead = false
+        ..createdAt = now);
+    }
+
+    if (notifications.isEmpty) return;
+    await isar.writeTxn(() async {
+      await isar.appNotifications.putAll(notifications);
+    });
+  }
+
+  /// 標記單則通知為已讀
+  static Future<void> markAsRead(AppNotification notification) async {
+    if (notification.isRead) return;
+    final isar = await DatabaseService.instance;
+    notification.isRead = true;
+    await isar.writeTxn(() async {
+      await isar.appNotifications.put(notification);
+    });
+  }
+
+  /// 標記全部已讀
+  static Future<void> markAllAsRead(String recipientId) async {
+    final isar = await DatabaseService.instance;
+    final unread = await isar.appNotifications
+        .filter()
+        .recipientIdEqualTo(recipientId)
+        .isReadEqualTo(false)
+        .findAll();
+    if (unread.isEmpty) return;
+    for (final n in unread) {
+      n.isRead = true;
+    }
+    await isar.writeTxn(() async {
+      await isar.appNotifications.putAll(unread);
+    });
+  }
+}

--- a/lib/screens/home/home_page.dart
+++ b/lib/screens/home/home_page.dart
@@ -8,6 +8,8 @@ import '../../providers/member_provider.dart';
 import '../../providers/balance_provider.dart';
 import '../../utils/formatters.dart';
 import '../../widgets/member_avatar.dart';
+import '../../providers/notification_provider.dart';
+import '../notification/notification_page.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -26,6 +28,7 @@ class HomePage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('家計本'),
         actions: [
+          _NotificationBell(),
           currentUser.when(
             data: (user) => user != null
                 ? TextButton.icon(
@@ -224,6 +227,24 @@ class _DebtOverviewCard extends StatelessWidget {
                   ]),
                 )),
         ]),
+      ),
+    );
+  }
+}
+
+class _NotificationBell extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final unreadCount = ref.watch(unreadNotificationCountProvider).valueOrNull ?? 0;
+    return IconButton(
+      onPressed: () => Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const NotificationPage()),
+      ),
+      icon: Badge(
+        isLabelVisible: unreadCount > 0,
+        label: Text('$unreadCount'),
+        child: const Icon(Icons.notifications_outlined),
       ),
     );
   }

--- a/lib/screens/notification/notification_page.dart
+++ b/lib/screens/notification/notification_page.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../providers/notification_provider.dart';
+import '../../providers/member_provider.dart';
+
+class NotificationPage extends ConsumerWidget {
+  const NotificationPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final notifications = ref.watch(userNotificationsProvider);
+    final currentUser = ref.watch(currentUserProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('通知'),
+        actions: [
+          currentUser.when(
+            data: (user) => user != null
+                ? TextButton(
+                    onPressed: () => NotificationService.markAllAsRead(user.id),
+                    child: const Text('全部已讀'),
+                  )
+                : const SizedBox.shrink(),
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
+          ),
+        ],
+      ),
+      body: notifications.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('$e')),
+        data: (items) {
+          if (items.isEmpty) {
+            return Center(
+              child: Column(mainAxisSize: MainAxisSize.min, children: [
+                Icon(Icons.notifications_none, size: 64,
+                    color: theme.colorScheme.primary.withValues(alpha: 0.3)),
+                const SizedBox(height: 16),
+                Text('目前沒有通知', style: theme.textTheme.titleMedium),
+              ]),
+            );
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final n = items[index];
+              final icon = switch (n.type) {
+                'split_expense' => Icons.receipt_long,
+                'settlement' => Icons.payments_outlined,
+                _ => Icons.notifications_outlined,
+              };
+              return ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  backgroundColor: n.isRead
+                      ? theme.colorScheme.surfaceContainerHighest
+                      : theme.colorScheme.primary.withValues(alpha: 0.1),
+                  foregroundColor: n.isRead
+                      ? theme.colorScheme.onSurface.withValues(alpha: 0.5)
+                      : theme.colorScheme.primary,
+                  child: Icon(icon, size: 20),
+                ),
+                title: Text(
+                  n.title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: n.isRead ? FontWeight.normal : FontWeight.w600,
+                  ),
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(n.body, style: theme.textTheme.bodySmall),
+                    const SizedBox(height: 2),
+                    Text(
+                      DateFormat('MM/dd HH:mm', 'zh_TW').format(n.createdAt),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                      ),
+                    ),
+                  ],
+                ),
+                trailing: n.isRead
+                    ? null
+                    : Container(
+                        width: 8, height: 8,
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primary,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                onTap: () => NotificationService.markAsRead(n),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -7,6 +7,7 @@ import '../models/balance.dart';
 import '../models/category.dart';
 import '../models/settlement.dart';
 import '../models/activity_log.dart';
+import '../models/app_notification.dart';
 import '../models/enums.dart';
 import 'package:uuid/uuid.dart';
 
@@ -34,6 +35,7 @@ class DatabaseService {
         CategorySchema,
         SettlementSchema,
         ActivityLogSchema,
+        AppNotificationSchema,
       ],
       directory: dir.path,
       name: 'family_ledger',


### PR DESCRIPTION
## Summary
- Add `AppNotification` Isar collection for in-app notifications
- Add notification bell icon in home AppBar with unread count badge
- When shared expenses are created, all split participants (except payer) receive notifications
- Notification page with mark-as-read and mark-all-as-read functionality

Closes #18

## Test plan
- [ ] Home page shows bell icon in AppBar
- [ ] Add a shared expense → other members see notification badge increment
- [ ] Tap bell → notification page shows the split expense notification
- [ ] Tap notification → marks as read (blue dot disappears)
- [ ] "全部已讀" button marks all notifications as read

🤖 Generated with [Claude Code](https://claude.com/claude-code)