### PR TITLE
feat(expense): add payment method field

### DIFF
--- a/lib/models/enums.dart
+++ b/lib/models/enums.dart
@@ -11,6 +11,13 @@ enum SplitMethod {
   custom,     // 自訂金額
 }
 
+/// 付款方式
+enum PaymentMethod {
+  cash,       // 現金
+  creditCard, // 信用卡
+  transfer,   // 轉帳
+}
+
 /// 成員角色
 enum MemberRole {
   admin,

--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -49,6 +49,10 @@ class Expense {
   /// 拆帳明細（嵌入式）
   late List<SplitDetail> splits;
 
+  /// 付款方式：cash / creditCard / transfer
+  @Enumerated(EnumType.name)
+  PaymentMethod paymentMethod = PaymentMethod.cash;
+
   /// 發票照片本地路徑
   String? receiptPath;
 

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -62,6 +62,7 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     required String payerName,
     required List<SplitDetail> splits,
     String? receiptPath,
+    PaymentMethod paymentMethod = PaymentMethod.cash,
     String? note,
     required String createdBy,
   }) async {
@@ -81,6 +82,7 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       ..payerId = payerId
       ..payerName = payerName
       ..splits = splits
+      ..paymentMethod = paymentMethod
       ..receiptPath = receiptPath
       ..note = note
       ..createdBy = createdBy

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -42,6 +42,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   Map<String, double> _customAmounts = {};
   Map<String, TextEditingController> _pctCtrl = {};
   Map<String, TextEditingController> _customCtrl = {};
+  PaymentMethod _paymentMethod = PaymentMethod.cash;
   String? _receiptPath;
   TextEditingController? _descAutoController;
 
@@ -62,6 +63,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       _isShared = e.isShared;
       _splitMethod = e.splitMethod;
       _payerId = e.payerId;
+      _paymentMethod = e.paymentMethod;
       _receiptPath = isDuplicate ? null : e.receiptPath;
       _participantIds = e.splits.where((s) => s.isParticipant).map((s) => s.memberId).toSet();
       if (_splitMethod == SplitMethod.percentage) {
@@ -312,6 +314,19 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
                 items: (catList.isNotEmpty ? catList.map((c) => c.name).toList()
                     : ['餐飲', '交通', '購物', '其他']).map((c) => DropdownMenuItem(value: c, child: Text(c))).toList(),
                 onChanged: (v) => setState(() => _selectedCategory = v!),
+              ),
+              const Gap(16),
+              // 付款方式
+              Text('付款方式', style: theme.textTheme.labelLarge),
+              const Gap(8),
+              SegmentedButton<PaymentMethod>(
+                segments: const [
+                  ButtonSegment(value: PaymentMethod.cash, label: Text('現金'), icon: Icon(Icons.money)),
+                  ButtonSegment(value: PaymentMethod.creditCard, label: Text('信用卡'), icon: Icon(Icons.credit_card)),
+                  ButtonSegment(value: PaymentMethod.transfer, label: Text('轉帳'), icon: Icon(Icons.swap_horiz)),
+                ],
+                selected: {_paymentMethod},
+                onSelectionChanged: (v) => setState(() => _paymentMethod = v.first),
               ),
               const Gap(16),
               // 支出類型
@@ -579,6 +594,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         ..payerId = _payerId!
         ..payerName = nameMap[_payerId] ?? ''
         ..splits = splits
+        ..paymentMethod = _paymentMethod
         ..receiptPath = _receiptPath
         ..note = _noteController.text.trim().isEmpty ? null : _noteController.text.trim();
       await ref.read(expenseNotifierProvider.notifier).updateExpense(existing);
@@ -588,7 +604,7 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         amount: amount, category: _selectedCategory, isShared: _isShared,
         splitMethod: _splitMethod, payerId: _payerId!,
         payerName: nameMap[_payerId] ?? '', splits: splits,
-        receiptPath: _receiptPath,
+        paymentMethod: _paymentMethod, receiptPath: _receiptPath,
         note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
         createdBy: currentUser?.id ?? _payerId!,
       );

--- a/lib/screens/records/records_page.dart
+++ b/lib/screens/records/records_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'package:gap/gap.dart';
 import '../../models/expense.dart';
+import '../../models/enums.dart';
 import '../../providers/expense_provider.dart';
 import '../../utils/formatters.dart';
 import '../expense/expense_form_page.dart';
@@ -128,7 +129,7 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                           ),
                           title: Text(e.description),
                           subtitle: Row(children: [
-                            Expanded(child: Text('${e.category} · ${e.payerName}付${e.isShared ? ' · 共同' : ''}')),
+                            Expanded(child: Text('${e.category} · ${e.payerName}付 · ${_paymentLabel(e.paymentMethod)}${e.isShared ? ' · 共同' : ''}')),
                             if (e.receiptPath != null) GestureDetector(
                               onTap: () => _viewReceipt(e.receiptPath!),
                               child: Icon(Icons.receipt_long, size: 16,
@@ -148,6 +149,12 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
       ),
     );
   }
+
+  String _paymentLabel(PaymentMethod method) => switch (method) {
+    PaymentMethod.cash => '現金',
+    PaymentMethod.creditCard => '信用卡',
+    PaymentMethod.transfer => '轉帳',
+  };
 
   void _viewReceipt(String path) {
     Navigator.push(context, MaterialPageRoute(


### PR DESCRIPTION
## Summary
- Add `PaymentMethod` enum (cash, creditCard, transfer) to `enums.dart`
- Add `paymentMethod` field to `Expense` model (default: cash)
- Add SegmentedButton selector in expense form page
- Display payment method in records list

Closes #23

## Test plan
- [ ] New expense form shows payment method selector (現金/信用卡/轉帳)
- [ ] Default selection is 現金
- [ ] Saved payment method persists and shows in records
- [ ] Edit expense preserves payment method
- [ ] Duplicate expense copies payment method

🤖 Generated with [Claude Code](https://claude.com/claude-code)