### PR TITLE
feat(notification): add local push notifications for iOS and macOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
+import 'services/local_notification_service.dart';
 import 'app.dart';
 
 void main() async {
@@ -12,6 +13,9 @@ void main() async {
 
   // 初始化 Isar 資料庫
   await DatabaseService.instance;
+
+  // 初始化本地推播通知
+  await LocalNotificationService.init();
 
   runApp(
     const ProviderScope(

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar/isar.dart';
 import '../models/app_notification.dart';
 import '../services/database_service.dart';
+import '../services/local_notification_service.dart';
 
 /// 目前使用者的未讀通知數
 final unreadNotificationCountProvider = StreamProvider<int>((ref) async* {
@@ -67,6 +68,20 @@ class NotificationService {
     await isar.writeTxn(() async {
       await isar.appNotifications.putAll(notifications);
     });
+
+    // 觸發本地推播通知（僅通知當前使用者）
+    final currentUser = await DatabaseService.getCurrentUser();
+    if (currentUser != null) {
+      for (final n in notifications) {
+        if (n.recipientId == currentUser.id) {
+          await LocalNotificationService.show(
+            id: n.isarId,
+            title: n.title,
+            body: n.body,
+          );
+        }
+      }
+    }
   }
 
   /// 標記單則通知為已讀

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+/// 本地推播通知服務（iOS + macOS）
+class LocalNotificationService {
+  static final _plugin = FlutterLocalNotificationsPlugin();
+  static bool _initialized = false;
+
+  /// 初始化通知（在 app 啟動時呼叫一次）
+  static Future<void> init() async {
+    if (_initialized) return;
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: darwinSettings,
+      macOS: darwinSettings,
+    );
+
+    await _plugin.initialize(initSettings);
+    _initialized = true;
+
+    // 請求 iOS 權限
+    if (Platform.isIOS) {
+      await _plugin
+          .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(alert: true, badge: true, sound: true);
+    }
+    if (Platform.isMacOS) {
+      await _plugin
+          .resolvePlatformSpecificImplementation<MacOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(alert: true, badge: true, sound: true);
+    }
+  }
+
+  /// 發送本地通知
+  static Future<void> show({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    if (!_initialized) await init();
+
+    const darwinDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const details = NotificationDetails(
+      iOS: darwinDetails,
+      macOS: darwinDetails,
+      android: AndroidNotificationDetails(
+        'split_expense',
+        '分攤費用通知',
+        channelDescription: '當有新的分攤費用時通知',
+        importance: Importance.high,
+        priority: Priority.high,
+      ),
+    );
+
+    await _plugin.show(id, title, body, details);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `LocalNotificationService` wrapping flutter_local_notifications for iOS and macOS
- Initialize at app startup with platform-specific permission requests
- When split expenses create in-app notifications, also fire system push notifications
- Works on both iOS and macOS (Darwin notification settings shared)

Closes #21

## Test plan
- [ ] App launch requests notification permission on iOS/macOS
- [ ] Add shared expense → system notification appears for current user if they owe
- [ ] Notification shows title and share amount details
- [ ] macOS also shows notification banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)