### PR TITLE
feat(sync): add Firebase Firestore sync architecture

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -1,0 +1,96 @@
+# Firebase 設定指南
+
+## 前置條件
+- 安裝 Firebase CLI：`npm install -g firebase-tools`
+- 安裝 FlutterFire CLI：`dart pub global activate flutterfire_cli`
+- 有 Google 帳號
+
+## 步驟
+
+### 1. 建立 Firebase 專案
+
+1. 前往 [Firebase Console](https://console.firebase.google.com/)
+2. 點「新增專案」→ 輸入名稱（如 `family-ledger`）
+3. 選擇是否啟用 Google Analytics（可跳過）
+4. 等待專案建立完成
+
+### 2. 啟用 Firestore
+
+1. 在 Firebase Console 左側選單 → **Firestore Database**
+2. 點「建立資料庫」
+3. 選擇地區：`asia-east1`（台灣）或 `asia-northeast1`（東京）
+4. 選「正式模式」（之後設定 Security Rules）
+
+### 3. 啟用 Authentication
+
+1. 左側選單 → **Authentication** → **開始使用**
+2. 在「登入方式」分頁 → 啟用「匿名」登入
+3. （未來可加入 Google Sign-In、Apple Sign-In）
+
+### 4. 設定 FlutterFire
+
+在專案根目錄執行：
+
+```bash
+# 登入 Firebase
+firebase login
+
+# 自動設定 Flutter 專案（會產生 firebase_options.dart）
+flutterfire configure --project=你的專案ID
+```
+
+選擇平台時勾選：
+- ✅ iOS
+- ✅ macOS
+- ✅ Android（如果需要）
+
+### 5. iOS 額外設定
+
+`flutterfire configure` 會自動處理大部分設定。確認：
+
+- `ios/Runner/GoogleService-Info.plist` 已產生
+- `macos/Runner/GoogleService-Info.plist` 已產生
+
+### 6. 設定 Firestore Security Rules
+
+在 Firebase Console → Firestore → 規則，貼上：
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // 群組：只有擁有者和成員可讀寫
+    match /groups/{groupId} {
+      allow read, write: if request.auth != null;
+
+      match /members/{memberId} {
+        allow read, write: if request.auth != null;
+      }
+      match /expenses/{expenseId} {
+        allow read, write: if request.auth != null;
+      }
+      match /settlements/{settlementId} {
+        allow read, write: if request.auth != null;
+      }
+    }
+  }
+}
+```
+
+> 注意：以上是基本規則。正式上線前應改為更嚴格的規則（按 groupId 成員驗證）。
+
+### 7. 啟用同步
+
+`flutterfire configure` 完成後，在 `lib/main.dart` 取消以下註解：
+
+```dart
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
+
+// 在 main() 中：
+await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+```
+
+### 驗證
+
+執行 `flutter run`，如果沒有錯誤，Firebase 已成功連接。

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,20 @@
+// 此檔案由 FlutterFire CLI 自動產生
+// 請執行以下指令來產生真正的配置：
+//   dart pub global activate flutterfire_cli
+//   flutterfire configure
+//
+// 產生後此檔案會被覆蓋，請勿手動編輯。
+//
+// 詳見：https://firebase.google.com/docs/flutter/setup
+
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    // TODO: 執行 `flutterfire configure` 後，此處會自動填入真實配置
+    throw UnsupportedError(
+      'Firebase 尚未設定。請執行 `flutterfire configure` 產生配置。',
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
 import 'services/local_notification_service.dart';
+// TODO: 執行 flutterfire configure 後取消以下註解
+// import 'package:firebase_core/firebase_core.dart';
+// import 'firebase_options.dart';
 import 'app.dart';
 
 void main() async {
@@ -13,6 +16,9 @@ void main() async {
 
   // 初始化 Isar 資料庫
   await DatabaseService.instance;
+
+  // TODO: 執行 flutterfire configure 後取消以下註解
+  // await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
   // 初始化本地推播通知
   await LocalNotificationService.init();

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -9,6 +9,7 @@ import '../services/image_storage_service.dart';
 import 'balance_provider.dart';
 import 'activity_log_provider.dart';
 import 'notification_provider.dart';
+import '../services/firebase_sync_service.dart';
 
 const _uuid = Uuid();
 
@@ -97,6 +98,10 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       description: '$payerName 新增支出「$description」NT\$ ${amount.toStringAsFixed(0)}',
       entityId: expense.id,
     );
+    // Firebase 同步（忽略失敗，本地優先）
+    if (FirebaseSyncService.isSignedIn && groupId != null) {
+      FirebaseSyncService.syncExpenseUp(groupId, expense).catchError((_) {});
+    }
     if (isShared) {
       await NotificationService.notifySplitExpense(
         expenseId: expense.id,
@@ -125,6 +130,10 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       description: '${expense.payerName} 編輯支出「${expense.description}」',
       entityId: expense.id,
     );
+    if (FirebaseSyncService.isSignedIn) {
+      final gid = expense.groupId;
+      FirebaseSyncService.syncExpenseUp(gid, expense).catchError((_) {});
+    }
     if (expense.isShared) {
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }
@@ -146,6 +155,9 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       description: '刪除支出「${expense.description}」NT\$ ${expense.amount.toStringAsFixed(0)}',
       entityId: expense.id,
     );
+    if (FirebaseSyncService.isSignedIn) {
+      FirebaseSyncService.deleteExpenseRemote(expense.groupId, expense.id).catchError((_) {});
+    }
     if (wasShared) {
       await ref.read(balanceNotifierProvider.notifier).recalculate();
     }

--- a/lib/providers/settlement_provider.dart
+++ b/lib/providers/settlement_provider.dart
@@ -5,6 +5,7 @@ import '../models/settlement.dart';
 import '../services/database_service.dart';
 import 'balance_provider.dart';
 import 'activity_log_provider.dart';
+import '../services/firebase_sync_service.dart';
 
 const _uuid = Uuid();
 
@@ -52,6 +53,9 @@ class SettlementNotifier extends AsyncNotifier<void> {
       description: '$fromMemberName 付款給 $toMemberName NT\$ ${amount.toStringAsFixed(0)}',
       entityId: settlement.id,
     );
+    if (FirebaseSyncService.isSignedIn) {
+      FirebaseSyncService.syncSettlementUp(groupId, settlement).catchError((_) {});
+    }
     await ref.read(balanceNotifierProvider.notifier).recalculate();
   }
 
@@ -66,6 +70,9 @@ class SettlementNotifier extends AsyncNotifier<void> {
       description: '刪除付款記錄：${settlement.fromMemberName} → ${settlement.toMemberName} NT\$ ${settlement.amount.toStringAsFixed(0)}',
       entityId: settlement.id,
     );
+    if (FirebaseSyncService.isSignedIn) {
+      FirebaseSyncService.deleteSettlementRemote(settlement.groupId, settlement.id).catchError((_) {});
+    }
     await ref.read(balanceNotifierProvider.notifier).recalculate();
   }
 }

--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/firebase_sync_service.dart';
+
+/// 同步狀態
+enum SyncStatus { idle, syncing, error, disabled }
+
+/// 同步狀態 provider
+final syncStatusProvider = StateProvider<SyncStatus>((ref) => SyncStatus.disabled);
+
+/// 同步錯誤訊息
+final syncErrorProvider = StateProvider<String?>((ref) => null);
+
+/// 是否已啟用 Firebase
+final firebaseEnabledProvider = StateProvider<bool>((ref) => false);
+
+/// Firebase 登入狀態
+final firebaseUserProvider = Provider<bool>((ref) {
+  return FirebaseSyncService.isSignedIn;
+});

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -1,0 +1,214 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:isar/isar.dart';
+import '../models/expense.dart';
+import '../models/family_member.dart';
+import '../models/family_group.dart';
+import '../models/settlement.dart';
+import '../models/enums.dart';
+import '../models/split_detail.dart';
+import 'database_service.dart';
+
+/// Firebase Firestore 雙向同步服務
+///
+/// 資料結構：
+///   groups/{groupId}
+///   groups/{groupId}/members/{memberId}
+///   groups/{groupId}/expenses/{expenseId}
+///   groups/{groupId}/settlements/{settlementId}
+///
+/// 使用前必須：
+/// 1. 在 Firebase Console 建立專案
+/// 2. 執行 `flutterfire configure` 產生 firebase_options.dart
+/// 3. 在 main.dart 呼叫 `Firebase.initializeApp()`
+/// 4. 設定 Firestore Security Rules
+class FirebaseSyncService {
+  static FirebaseFirestore get _db => FirebaseFirestore.instance;
+  static FirebaseAuth get _auth => FirebaseAuth.instance;
+
+  /// 目前登入的 Firebase 使用者
+  static User? get currentUser => _auth.currentUser;
+
+  /// 是否已登入
+  static bool get isSignedIn => currentUser != null;
+
+  // ── 匿名登入（最簡方案，可後續升級為 Google Sign-In） ──
+
+  static Future<User?> signInAnonymously() async {
+    final credential = await _auth.signInAnonymously();
+    return credential.user;
+  }
+
+  // ── 群組同步 ──
+
+  static CollectionReference<Map<String, dynamic>> _groupsRef() =>
+      _db.collection('groups');
+
+  static DocumentReference<Map<String, dynamic>> _groupDoc(String groupId) =>
+      _groupsRef().doc(groupId);
+
+  /// 將本地群組上傳到 Firestore
+  static Future<void> syncGroupUp(FamilyGroup group) async {
+    await _groupDoc(group.id).set({
+      'name': group.name,
+      'isPrimary': group.isPrimary,
+      'createdAt': Timestamp.fromDate(group.createdAt),
+      'updatedAt': Timestamp.fromDate(group.updatedAt),
+      'ownerUid': currentUser?.uid,
+    }, SetOptions(merge: true));
+  }
+
+  // ── 成員同步 ──
+
+  static CollectionReference<Map<String, dynamic>> _membersRef(String groupId) =>
+      _groupDoc(groupId).collection('members');
+
+  static Future<void> syncMemberUp(String groupId, FamilyMember member) async {
+    await _membersRef(groupId).doc(member.id).set({
+      'name': member.name,
+      'isCurrentUser': member.isCurrentUser,
+      'createdAt': Timestamp.fromDate(member.createdAt),
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> deleteMemberRemote(String groupId, String memberId) async {
+    await _membersRef(groupId).doc(memberId).delete();
+  }
+
+  // ── 支出同步 ──
+
+  static CollectionReference<Map<String, dynamic>> _expensesRef(String groupId) =>
+      _groupDoc(groupId).collection('expenses');
+
+  static Future<void> syncExpenseUp(String groupId, Expense expense) async {
+    await _expensesRef(groupId).doc(expense.id).set({
+      'date': Timestamp.fromDate(expense.date),
+      'description': expense.description,
+      'amount': expense.amount,
+      'category': expense.category,
+      'isShared': expense.isShared,
+      'splitMethod': expense.splitMethod.name,
+      'payerId': expense.payerId,
+      'payerName': expense.payerName,
+      'paymentMethod': expense.paymentMethod.name,
+      'splits': expense.splits.map((s) => {
+        'memberId': s.memberId,
+        'memberName': s.memberName,
+        'shareAmount': s.shareAmount,
+        'paidAmount': s.paidAmount,
+        'isParticipant': s.isParticipant,
+      }).toList(),
+      'receiptPath': expense.receiptPath,
+      'note': expense.note,
+      'createdBy': expense.createdBy,
+      'createdAt': Timestamp.fromDate(expense.createdAt),
+      'updatedAt': Timestamp.fromDate(expense.updatedAt),
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> deleteExpenseRemote(String groupId, String expenseId) async {
+    await _expensesRef(groupId).doc(expenseId).delete();
+  }
+
+  // ── 結算同步 ──
+
+  static CollectionReference<Map<String, dynamic>> _settlementsRef(String groupId) =>
+      _groupDoc(groupId).collection('settlements');
+
+  static Future<void> syncSettlementUp(String groupId, Settlement settlement) async {
+    await _settlementsRef(groupId).doc(settlement.id).set({
+      'fromMemberId': settlement.fromMemberId,
+      'fromMemberName': settlement.fromMemberName,
+      'toMemberId': settlement.toMemberId,
+      'toMemberName': settlement.toMemberName,
+      'amount': settlement.amount,
+      'note': settlement.note,
+      'date': Timestamp.fromDate(settlement.date),
+      'createdAt': Timestamp.fromDate(settlement.createdAt),
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> deleteSettlementRemote(String groupId, String settlementId) async {
+    await _settlementsRef(groupId).doc(settlementId).delete();
+  }
+
+  // ── 下載同步（Firestore → 本地 Isar） ──
+
+  /// 監聽遠端支出變更，即時同步到本地
+  static Stream<QuerySnapshot<Map<String, dynamic>>> watchExpenses(String groupId) {
+    return _expensesRef(groupId).orderBy('updatedAt', descending: true).snapshots();
+  }
+
+  /// 將遠端支出寫入本地 Isar（merge 邏輯：以 updatedAt 較新者為準）
+  static Future<void> mergeExpenseFromRemote(
+      Map<String, dynamic> data, String expenseId) async {
+    final isar = await DatabaseService.instance;
+    final local = await isar.expenses.filter().idEqualTo(expenseId).findFirst();
+
+    final remoteUpdatedAt = (data['updatedAt'] as Timestamp).toDate();
+
+    // 如果本地已有且較新，跳過
+    if (local != null && local.updatedAt.isAfter(remoteUpdatedAt)) return;
+
+    final expense = Expense()
+      ..id = expenseId
+      ..groupId = (await DatabaseService.getPrimaryGroupId()) ?? ''
+      ..date = (data['date'] as Timestamp).toDate()
+      ..description = data['description'] as String
+      ..amount = (data['amount'] as num).toDouble()
+      ..category = data['category'] as String
+      ..isShared = data['isShared'] as bool
+      ..splitMethod = SplitMethod.values.firstWhere(
+          (e) => e.name == data['splitMethod'],
+          orElse: () => SplitMethod.equal)
+      ..payerId = data['payerId'] as String
+      ..payerName = data['payerName'] as String
+      ..paymentMethod = PaymentMethod.values.firstWhere(
+          (e) => e.name == (data['paymentMethod'] ?? 'cash'),
+          orElse: () => PaymentMethod.cash)
+      ..splits = ((data['splits'] as List?) ?? []).map((s) {
+        final map = s as Map<String, dynamic>;
+        return SplitDetail()
+          ..memberId = map['memberId'] as String
+          ..memberName = map['memberName'] as String
+          ..shareAmount = (map['shareAmount'] as num).toDouble()
+          ..paidAmount = (map['paidAmount'] as num).toDouble()
+          ..isParticipant = map['isParticipant'] as bool;
+      }).toList()
+      ..receiptPath = data['receiptPath'] as String?
+      ..note = data['note'] as String?
+      ..createdBy = data['createdBy'] as String
+      ..createdAt = (data['createdAt'] as Timestamp).toDate()
+      ..updatedAt = remoteUpdatedAt;
+
+    // 保留本地 isarId
+    if (local != null) expense.isarId = local.isarId;
+
+    await isar.writeTxn(() async {
+      await isar.expenses.put(expense);
+    });
+  }
+
+  // ── 邀請碼加入群組 ──
+
+  /// 產生 6 碼邀請碼（存在群組 doc 上）
+  static Future<String> generateInviteCode(String groupId) async {
+    final code = DateTime.now().millisecondsSinceEpoch.toRadixString(36).substring(2, 8).toUpperCase();
+    await _groupDoc(groupId).update({
+      'inviteCode': code,
+      'inviteExpiry': Timestamp.fromDate(DateTime.now().add(const Duration(hours: 24))),
+    });
+    return code;
+  }
+
+  /// 用邀請碼加入群組
+  static Future<String?> joinGroupByCode(String code) async {
+    final snap = await _groupsRef()
+        .where('inviteCode', isEqualTo: code)
+        .where('inviteExpiry', isGreaterThan: Timestamp.now())
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) return null;
+    return snap.docs.first.id;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,11 +35,16 @@ dependencies:
   pdf: ^3.10.8
   printing: ^5.12.0
   csv: ^6.0.0
-  share_plus: ^9.0.0
+  share_plus: ^12.0.1
 
   # 語音 / AI
   speech_to_text: ^6.6.0
   http: ^1.2.1
+
+  # Firebase（需先執行 flutterfire configure 產生 firebase_options.dart）
+  firebase_core: ^3.8.1
+  cloud_firestore: ^5.6.5
+  firebase_auth: ^5.4.3
 
   # 工具
   uuid: ^4.3.3


### PR DESCRIPTION
## Summary
- Add `FirebaseSyncService` with Firestore CRUD for groups, members, expenses, settlements
- Local-first architecture: Isar writes always succeed, Firebase sync is fire-and-forget
- Add invite code mechanism (6-char, 24h expiry) for family group sharing
- Add `sync_provider.dart` with sync status tracking
- Integrate sync-up into expense/settlement providers
- Include `docs/firebase-setup.md` step-by-step guide
- Upgrade `share_plus` ^9 → ^12 for Firebase dependency compatibility

**Note:** Firebase init is commented out in `main.dart`. User must run `flutterfire configure` first.

Closes #16

## Test plan
- [ ] `flutter analyze` passes with no errors
- [ ] App runs without Firebase (sync calls are no-op when not signed in)
- [ ] After Firebase setup: expenses sync to Firestore on create/edit/delete
- [ ] After Firebase setup: settlements sync to Firestore
- [ ] Invite code generation and join works

🤖 Generated with [Claude Code](https://claude.com/claude-code)