### PR TITLE
chore(firebase): activate Firebase with real project config

### DIFF
--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyD9FyDSM4-acovBVfMvf_2kLW1IaJcVsMQ</string>
+	<key>GCM_SENDER_ID</key>
+	<string>137558877215</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.familyledger.familyLedger</string>
+	<key>PROJECT_ID</key>
+	<string>family-ledger-784ed</string>
+	<key>STORAGE_BUCKET</key>
+	<string>family-ledger-784ed.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:137558877215:ios:7101807b49be145b96a12a</string>
+</dict>
+</plist>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,20 +1,37 @@
-// 此檔案由 FlutterFire CLI 自動產生
-// 請執行以下指令來產生真正的配置：
-//   dart pub global activate flutterfire_cli
-//   flutterfire configure
-//
-// 產生後此檔案會被覆蓋，請勿手動編輯。
-//
-// 詳見：https://firebase.google.com/docs/flutter/setup
+// 由 GoogleService-Info.plist 手動產生
+// 如需更新，重新執行 flutterfire configure 或手動修改
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
-    // TODO: 執行 `flutterfire configure` 後，此處會自動填入真實配置
-    throw UnsupportedError(
-      'Firebase 尚未設定。請執行 `flutterfire configure` 產生配置。',
-    );
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      default:
+        throw UnsupportedError('此平台尚未設定 Firebase：$defaultTargetPlatform');
+    }
   }
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'AIzaSyD9FyDSM4-acovBVfMvf_2kLW1IaJcVsMQ',
+    appId: '1:137558877215:ios:7101807b49be145b96a12a',
+    messagingSenderId: '137558877215',
+    projectId: 'family-ledger-784ed',
+    storageBucket: 'family-ledger-784ed.firebasestorage.app',
+    iosBundleId: 'com.familyledger.familyLedger',
+  );
+
+  // macOS 共用 iOS 的配置（同一個 Apple app）
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'AIzaSyD9FyDSM4-acovBVfMvf_2kLW1IaJcVsMQ',
+    appId: '1:137558877215:ios:7101807b49be145b96a12a',
+    messagingSenderId: '137558877215',
+    projectId: 'family-ledger-784ed',
+    storageBucket: 'family-ledger-784ed.firebasestorage.app',
+    iosBundleId: 'com.familyledger.familyLedger',
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
 import 'services/local_notification_service.dart';
-// TODO: 執行 flutterfire configure 後取消以下註解
-// import 'package:firebase_core/firebase_core.dart';
-// import 'firebase_options.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 import 'app.dart';
 
 void main() async {
@@ -17,8 +16,8 @@ void main() async {
   // 初始化 Isar 資料庫
   await DatabaseService.instance;
 
-  // TODO: 執行 flutterfire configure 後取消以下註解
-  // await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  // 初始化 Firebase
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
   // 初始化本地推播通知
   await LocalNotificationService.init();

--- a/macos/Runner/GoogleService-Info.plist
+++ b/macos/Runner/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyD9FyDSM4-acovBVfMvf_2kLW1IaJcVsMQ</string>
+	<key>GCM_SENDER_ID</key>
+	<string>137558877215</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.familyledger.familyShareLedger</string>
+	<key>PROJECT_ID</key>
+	<string>family-ledger-784ed</string>
+	<key>STORAGE_BUCKET</key>
+	<string>family-ledger-784ed.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:137558877215:ios:67e1971734b293f996a12a</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add real `GoogleService-Info.plist` for iOS and macOS (project: family-ledger-784ed)
- Generate `firebase_options.dart` with actual API keys and app IDs
- Enable `Firebase.initializeApp()` in main.dart (previously commented out)

## Test plan
- [ ] App launches without Firebase errors on iOS/macOS
- [ ] Firebase Console shows connected app

🤖 Generated with [Claude Code](https://claude.com/claude-code)