### PR TITLE
security(firestore): production-grade Security Rules

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -53,31 +53,19 @@ flutterfire configure --project=你的專案ID
 
 ### 6. 設定 Firestore Security Rules
 
-在 Firebase Console → Firestore → 規則，貼上：
+在 Firebase Console → Firestore → 規則，貼上 `firestore.rules` 檔案的內容。
 
-```
-rules_version = '2';
-service cloud.firestore {
-  match /databases/{database}/documents {
-    // 群組：只有擁有者和成員可讀寫
-    match /groups/{groupId} {
-      allow read, write: if request.auth != null;
-
-      match /members/{memberId} {
-        allow read, write: if request.auth != null;
-      }
-      match /expenses/{expenseId} {
-        allow read, write: if request.auth != null;
-      }
-      match /settlements/{settlementId} {
-        allow read, write: if request.auth != null;
-      }
-    }
-  }
-}
+或使用 Firebase CLI 部署：
+```bash
+firebase deploy --only firestore:rules
 ```
 
-> 注意：以上是基本規則。正式上線前應改為更嚴格的規則（按 groupId 成員驗證）。
+正式環境規則包含：
+- **群組成員驗證**：只有 `memberUids[]` 內的 UID 可讀寫
+- **擁有者特權**：僅 `ownerUid` 可刪除群組或轉移擁有權
+- **欄位型別驗證**：金額必須為正數且 < 1 億，描述 ≤ 200 字
+- **文件大小限制**：每筆文件最多 30 個欄位
+- **預設拒絕**：未定義的路徑全部拒絕存取
 
 ### 7. 啟用同步
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,115 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ─── 輔助函式 ───
+
+    // 是否已登入
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // 是否為群組成員
+    function isGroupMember(groupId) {
+      return isSignedIn() &&
+        request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberUids;
+    }
+
+    // 是否為群組擁有者
+    function isGroupOwner(groupId) {
+      return isSignedIn() &&
+        request.auth.uid == get(/databases/$(database)/documents/groups/$(groupId)).data.ownerUid;
+    }
+
+    // 資料大小限制
+    function isReasonableSize() {
+      return request.resource.data.keys().size() < 30;
+    }
+
+    // ─── 群組 ───
+
+    match /groups/{groupId} {
+
+      // 讀取：僅群組成員
+      allow read: if isGroupMember(groupId);
+
+      // 建立：任何已登入使用者（建群組）
+      // 必須包含 ownerUid = 自己，且 memberUids 包含自己
+      allow create: if isSignedIn()
+        && request.resource.data.ownerUid == request.auth.uid
+        && request.auth.uid in request.resource.data.memberUids
+        && request.resource.data.name is string
+        && request.resource.data.name.size() > 0
+        && request.resource.data.name.size() <= 50;
+
+      // 更新：僅群組成員，但 ownerUid 不可變更（除非是 owner 自己轉移）
+      allow update: if isGroupMember(groupId)
+        && isReasonableSize()
+        && (request.resource.data.ownerUid == resource.data.ownerUid
+            || isGroupOwner(groupId));
+
+      // 刪除：僅群組擁有者
+      allow delete: if isGroupOwner(groupId);
+
+      // ─── 成員 ───
+
+      match /members/{memberId} {
+        allow read: if isGroupMember(groupId);
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.name is string
+          && request.resource.data.name.size() > 0
+          && request.resource.data.name.size() <= 30;
+        allow update: if isGroupMember(groupId);
+        allow delete: if isGroupMember(groupId);
+      }
+
+      // ─── 支出 ───
+
+      match /expenses/{expenseId} {
+        allow read: if isGroupMember(groupId);
+
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.description is string
+          && request.resource.data.description.size() > 0
+          && request.resource.data.description.size() <= 200
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && request.resource.data.category is string
+          && request.resource.data.payerId is string
+          && request.resource.data.payerName is string
+          && isReasonableSize();
+
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && isReasonableSize();
+
+        allow delete: if isGroupMember(groupId);
+      }
+
+      // ─── 結算 ───
+
+      match /settlements/{settlementId} {
+        allow read: if isGroupMember(groupId);
+
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && request.resource.data.fromMemberId is string
+          && request.resource.data.toMemberId is string
+          && isReasonableSize();
+
+        allow update: if isGroupMember(groupId);
+        allow delete: if isGroupMember(groupId);
+      }
+    }
+
+    // ─── 其他路徑：全部拒絕 ───
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -49,13 +49,30 @@ class FirebaseSyncService {
 
   /// 將本地群組上傳到 Firestore
   static Future<void> syncGroupUp(FamilyGroup group) async {
+    final uid = currentUser?.uid;
     await _groupDoc(group.id).set({
       'name': group.name,
       'isPrimary': group.isPrimary,
       'createdAt': Timestamp.fromDate(group.createdAt),
       'updatedAt': Timestamp.fromDate(group.updatedAt),
-      'ownerUid': currentUser?.uid,
+      'ownerUid': uid,
+      // memberUids 用於 Security Rules 驗證成員身份
+      if (uid != null) 'memberUids': FieldValue.arrayUnion([uid]),
     }, SetOptions(merge: true));
+  }
+
+  /// 將 Firebase UID 加入群組成員清單（邀請加入時呼叫）
+  static Future<void> addMemberUid(String groupId, String uid) async {
+    await _groupDoc(groupId).update({
+      'memberUids': FieldValue.arrayUnion([uid]),
+    });
+  }
+
+  /// 將 Firebase UID 從群組移除
+  static Future<void> removeMemberUid(String groupId, String uid) async {
+    await _groupDoc(groupId).update({
+      'memberUids': FieldValue.arrayRemove([uid]),
+    });
   }
 
   // ── 成員同步 ──
@@ -201,7 +218,7 @@ class FirebaseSyncService {
     return code;
   }
 
-  /// 用邀請碼加入群組
+  /// 用邀請碼加入群組（同時將 UID 加入 memberUids）
   static Future<String?> joinGroupByCode(String code) async {
     final snap = await _groupsRef()
         .where('inviteCode', isEqualTo: code)
@@ -209,6 +226,11 @@ class FirebaseSyncService {
         .limit(1)
         .get();
     if (snap.docs.isEmpty) return null;
-    return snap.docs.first.id;
+    final groupId = snap.docs.first.id;
+    final uid = currentUser?.uid;
+    if (uid != null) {
+      await addMemberUid(groupId, uid);
+    }
+    return groupId;
   }
 }


### PR DESCRIPTION
## Summary
- Add `firestore.rules` with production-grade access control
- **群組成員驗證**: `memberUids[]` array check — only members can read/write
- **擁有者特權**: only `ownerUid` can delete group or transfer ownership
- **欄位驗證**: amount must be positive number < 100M, description ≤ 200 chars
- **文件大小限制**: max 30 fields per document
- **預設拒絕**: all undefined paths denied
- Update `FirebaseSyncService` to maintain `memberUids` on group sync and invite join
- Update `docs/firebase-setup.md` with production rules reference

Closes #30

## Security model
```
groups/{groupId}
  ├── ownerUid: string (creator's Firebase UID)
  ├── memberUids: string[] (all member Firebase UIDs)
  ├── members/{memberId} — CRUD: memberUids only
  ├── expenses/{expenseId} — CRUD: memberUids only, validated fields
  └── settlements/{settlementId} — CRUD: memberUids only, validated fields
```

## Deploy
```bash
firebase deploy --only firestore:rules
```
Or paste `firestore.rules` content into Firebase Console → Firestore → Rules.

## Test plan
- [ ] Non-member UID cannot read group data
- [ ] Member UID can CRUD expenses and settlements
- [ ] Only owner can delete group
- [ ] Invalid amount (negative, > 100M) rejected
- [ ] Empty description rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)