### PR TITLE
feat(expense): support multi-receipt photos (up to 10)

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -53,8 +53,11 @@ class Expense {
   @Enumerated(EnumType.name)
   PaymentMethod paymentMethod = PaymentMethod.cash;
 
-  /// 發票照片本地路徑
+  /// 發票照片本地路徑（保留向下相容）
   String? receiptPath;
+
+  /// 多張收據照片路徑（上限 10 張）
+  List<String> receiptPaths = [];
 
   /// 備註
   String? note;

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -63,6 +63,7 @@ class ExpenseNotifier extends AsyncNotifier<void> {
     required String payerName,
     required List<SplitDetail> splits,
     String? receiptPath,
+    List<String> receiptPaths = const [],
     PaymentMethod paymentMethod = PaymentMethod.cash,
     String? note,
     required String createdBy,
@@ -85,6 +86,7 @@ class ExpenseNotifier extends AsyncNotifier<void> {
       ..splits = splits
       ..paymentMethod = paymentMethod
       ..receiptPath = receiptPath
+      ..receiptPaths = receiptPaths
       ..note = note
       ..createdBy = createdBy
       ..createdAt = now

--- a/lib/screens/expense/expense_form_page.dart
+++ b/lib/screens/expense/expense_form_page.dart
@@ -44,7 +44,8 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
   Map<String, TextEditingController> _pctCtrl = {};
   Map<String, TextEditingController> _customCtrl = {};
   PaymentMethod _paymentMethod = PaymentMethod.cash;
-  String? _receiptPath;
+  List<String> _receiptPaths = [];
+  static const _maxPhotos = 10;
   TextEditingController? _descAutoController;
 
   String get _descText => (_descAutoController ?? _descController).text;
@@ -65,7 +66,13 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       _splitMethod = e.splitMethod;
       _payerId = e.payerId;
       _paymentMethod = e.paymentMethod;
-      _receiptPath = isDuplicate ? null : e.receiptPath;
+      if (!isDuplicate) {
+        _receiptPaths = [...e.receiptPaths];
+        // 向下相容：舊資料只有 receiptPath
+        if (_receiptPaths.isEmpty && e.receiptPath != null) {
+          _receiptPaths = [e.receiptPath!];
+        }
+      }
       _participantIds = e.splits.where((s) => s.isParticipant).map((s) => s.memberId).toSet();
       if (_splitMethod == SplitMethod.percentage) {
         final total = e.amount;
@@ -457,43 +464,50 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
                       prefixIcon: Icon(Icons.note_outlined), border: OutlineInputBorder()),
                   maxLines: 2),
               const Gap(16),
-              // 收據照片
-              Text('收據 / 發票照片', style: theme.textTheme.labelLarge),
-              const Gap(8),
-              if (_receiptPath != null) ...[
-                Stack(children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: Image.file(File(_receiptPath!),
-                        height: 200, width: double.infinity, fit: BoxFit.cover),
-                  ),
-                  Positioned(top: 8, right: 8, child: Row(mainAxisSize: MainAxisSize.min, children: [
-                    _CircleIconButton(
-                      icon: Icons.fullscreen,
-                      onTap: () => _viewReceiptFullScreen(_receiptPath!),
-                    ),
-                    const Gap(8),
-                    _CircleIconButton(
-                      icon: Icons.close,
-                      onTap: () {
-                        final old = _receiptPath;
-                        setState(() => _receiptPath = null);
-                        if (old != null) ImageStorageService.deleteReceipt(old);
-                      },
-                    ),
-                  ])),
-                ]),
+              // 收據照片（多張，上限 10 張）
+              Row(children: [
+                Text('收據 / 發票照片', style: theme.textTheme.labelLarge),
                 const Gap(8),
-                OutlinedButton.icon(
-                  onPressed: _pickReceipt,
-                  icon: const Icon(Icons.swap_horiz, size: 18),
-                  label: const Text('更換照片'),
+                Text('${_receiptPaths.length}/$_maxPhotos',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+              ]),
+              const Gap(8),
+              if (_receiptPaths.isNotEmpty) ...[
+                SizedBox(
+                  height: 120,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: _receiptPaths.length,
+                    separatorBuilder: (_, __) => const Gap(8),
+                    itemBuilder: (context, index) {
+                      final path = _receiptPaths[index];
+                      return Stack(children: [
+                        GestureDetector(
+                          onTap: () => _viewReceiptFullScreen(path),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(12),
+                            child: Image.file(File(path), width: 120, height: 120, fit: BoxFit.cover),
+                          ),
+                        ),
+                        Positioned(top: 4, right: 4, child: _CircleIconButton(
+                          icon: Icons.close,
+                          onTap: () {
+                            setState(() => _receiptPaths.removeAt(index));
+                            ImageStorageService.deleteReceipt(path);
+                          },
+                        )),
+                      ]);
+                    },
+                  ),
                 ),
-              ] else
+                const Gap(8),
+              ],
+              if (_receiptPaths.length < _maxPhotos)
                 OutlinedButton.icon(
                   onPressed: _pickReceipt,
                   icon: const Icon(Icons.camera_alt_outlined, size: 18),
-                  label: const Text('拍照或選擇照片'),
+                  label: Text(_receiptPaths.isEmpty ? '拍照或選擇照片' : '新增照片'),
                   style: OutlinedButton.styleFrom(minimumSize: const Size.fromHeight(48)),
                 ),
               const Gap(32),
@@ -523,12 +537,11 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
       ])),
     );
     if (source == null) return;
+    if (_receiptPaths.length >= _maxPhotos) return;
     final picked = await ImagePicker().pickImage(source: source, maxWidth: 1920, imageQuality: 85);
     if (picked == null) return;
-    final old = _receiptPath;
     final saved = await ImageStorageService.saveReceipt(picked.path);
-    if (old != null) await ImageStorageService.deleteReceipt(old);
-    setState(() => _receiptPath = saved);
+    setState(() => _receiptPaths.add(saved));
   }
 
   void _viewReceiptFullScreen(String path) {
@@ -603,7 +616,8 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         ..payerName = nameMap[_payerId] ?? ''
         ..splits = splits
         ..paymentMethod = _paymentMethod
-        ..receiptPath = _receiptPath
+        ..receiptPath = _receiptPaths.isNotEmpty ? _receiptPaths.first : null
+        ..receiptPaths = _receiptPaths
         ..note = _noteController.text.trim().isEmpty ? null : _noteController.text.trim();
       await ref.read(expenseNotifierProvider.notifier).updateExpense(existing);
     } else {
@@ -612,7 +626,9 @@ class _ExpenseFormPageState extends ConsumerState<ExpenseFormPage> {
         amount: amount, category: _selectedCategory, isShared: _isShared,
         splitMethod: _splitMethod, payerId: _payerId!,
         payerName: nameMap[_payerId] ?? '', splits: splits,
-        paymentMethod: _paymentMethod, receiptPath: _receiptPath,
+        paymentMethod: _paymentMethod,
+        receiptPath: _receiptPaths.isNotEmpty ? _receiptPaths.first : null,
+        receiptPaths: _receiptPaths,
         note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
         createdBy: currentUser?.id ?? _payerId!,
       );

--- a/lib/screens/records/records_page.dart
+++ b/lib/screens/records/records_page.dart
@@ -130,10 +130,15 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
                           title: Text(e.description),
                           subtitle: Row(children: [
                             Expanded(child: Text('${e.category} · ${e.payerName}付 · ${_paymentLabel(e.paymentMethod)}${e.isShared ? ' · 共同' : ''}')),
-                            if (e.receiptPath != null) GestureDetector(
-                              onTap: () => _viewReceipt(e.receiptPath!),
-                              child: Icon(Icons.receipt_long, size: 16,
-                                  color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                            if (e.receiptPaths.isNotEmpty || e.receiptPath != null) GestureDetector(
+                              onTap: () => _viewReceipts(e.receiptPaths.isNotEmpty ? e.receiptPaths : [e.receiptPath!]),
+                              child: Row(mainAxisSize: MainAxisSize.min, children: [
+                                Icon(Icons.receipt_long, size: 16,
+                                    color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                                if (e.receiptPaths.length > 1)
+                                  Text(' ${e.receiptPaths.length}', style: TextStyle(fontSize: 11,
+                                      color: theme.colorScheme.primary.withValues(alpha: 0.7))),
+                              ]),
                             ),
                           ]),
                           trailing: Text(Formatters.currency(e.amount),
@@ -156,16 +161,9 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
     PaymentMethod.transfer => '轉帳',
   };
 
-  void _viewReceipt(String path) {
+  void _viewReceipts(List<String> paths) {
     Navigator.push(context, MaterialPageRoute(
-      builder: (_) => Scaffold(
-        backgroundColor: Colors.black,
-        appBar: AppBar(backgroundColor: Colors.transparent, foregroundColor: Colors.white,
-            title: const Text('收據照片')),
-        body: Center(child: InteractiveViewer(
-          child: Image.file(File(path)),
-        )),
-      ),
+      builder: (_) => _ReceiptGalleryPage(paths: paths),
     ));
   }
 
@@ -185,5 +183,38 @@ class _RecordsPageState extends ConsumerState<RecordsPage> {
         ),
       ],
     ));
+  }
+}
+
+/// 收據照片瀏覽（左右滑動 PageView）
+class _ReceiptGalleryPage extends StatefulWidget {
+  final List<String> paths;
+  const _ReceiptGalleryPage({required this.paths});
+  @override
+  State<_ReceiptGalleryPage> createState() => _ReceiptGalleryPageState();
+}
+
+class _ReceiptGalleryPageState extends State<_ReceiptGalleryPage> {
+  int _current = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        foregroundColor: Colors.white,
+        title: Text('收據照片 ${_current + 1}/${widget.paths.length}'),
+      ),
+      body: PageView.builder(
+        itemCount: widget.paths.length,
+        onPageChanged: (i) => setState(() => _current = i),
+        itemBuilder: (context, index) => Center(
+          child: InteractiveViewer(
+            child: Image.file(File(widget.paths[index])),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -116,6 +116,7 @@ class FirebaseSyncService {
         'isParticipant': s.isParticipant,
       }).toList(),
       'receiptPath': expense.receiptPath,
+      'receiptPaths': expense.receiptPaths,
       'note': expense.note,
       'createdBy': expense.createdBy,
       'createdAt': Timestamp.fromDate(expense.createdAt),


### PR DESCRIPTION
## Summary
- Add `receiptPaths` (List<String>) field to Expense model, backward compatible with old `receiptPath`
- Horizontal scrollable photo grid in expense form (add/remove individual photos)
- Photo count badge on records list (e.g. receipt icon + "3")
- PageView gallery for full-screen photo browsing with swipe navigation
- Firebase sync updated to include receiptPaths

Closes #35

## Test plan
- [ ] Add expense with 0, 1, 5, 10 photos — all work
- [ ] Cannot add 11th photo (button disappears at 10)
- [ ] Remove individual photo from grid
- [ ] Records list shows photo count badge
- [ ] Tap receipt icon → gallery with swipe navigation
- [ ] Edit existing expense preserves photos
- [ ] Old expenses with single receiptPath still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)