### PR TITLE
feat(sync): enable Firebase live sync with invite code

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
 import 'services/local_notification_service.dart';
+import 'services/firebase_sync_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'app.dart';
@@ -18,6 +19,12 @@ void main() async {
 
   // 初始化 Firebase
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  // 匿名登入 Firebase（啟用跨裝置同步）
+  await FirebaseSyncService.signInAnonymously();
+
+  // 將本地群組上傳到 Firestore（首次同步）
+  await FirebaseSyncService.initialSync();
 
   // 初始化本地推播通知
   await LocalNotificationService.init();

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
+import '../../services/firebase_sync_service.dart';
+import '../../services/database_service.dart';
 import '../../providers/theme_provider.dart';
 import 'category_management_page.dart';
 import 'activity_log_page.dart';
@@ -176,6 +179,36 @@ class SettingsPage extends ConsumerWidget {
             ),
           ])),
           const Gap(16),
+          // 同步設定
+          Card(child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              Row(children: [
+                Icon(Icons.sync_outlined, color: theme.colorScheme.primary, size: 20),
+                const Gap(8),
+                Text('跨裝置同步', style: theme.textTheme.titleMedium),
+              ]),
+              const Gap(4),
+              Text(
+                FirebaseSyncService.isSignedIn ? '已連線 ✓' : '未連線',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: FirebaseSyncService.isSignedIn ? Colors.green : theme.colorScheme.error),
+              ),
+              const Gap(12),
+              SizedBox(width: double.infinity, child: OutlinedButton.icon(
+                icon: const Icon(Icons.link, size: 18),
+                label: const Text('產生邀請碼（分享給家人）'),
+                onPressed: () => _generateInviteCode(context),
+              )),
+              const Gap(8),
+              SizedBox(width: double.infinity, child: OutlinedButton.icon(
+                icon: const Icon(Icons.input, size: 18),
+                label: const Text('輸入邀請碼（加入群組）'),
+                onPressed: () => _joinByInviteCode(context, ref),
+              )),
+            ]),
+          )),
+          const Gap(16),
           // 其他設定
           Card(child: Column(children: [
             ListTile(
@@ -270,6 +303,97 @@ class SettingsPage extends ConsumerWidget {
             );
           }
         }, child: const Text('儲存')),
+      ],
+    ));
+  }
+
+  void _generateInviteCode(BuildContext context) async {
+    final groupId = await DatabaseService.getPrimaryGroupId();
+    if (groupId == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('尚未建立群組'), behavior: SnackBarBehavior.floating));
+      }
+      return;
+    }
+    try {
+      final code = await FirebaseSyncService.generateInviteCode(groupId);
+      if (!context.mounted) return;
+      showDialog(context: context, builder: (ctx) => AlertDialog(
+        title: const Text('邀請碼'),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          const Text('把這組邀請碼傳給家人，在他們的裝置上輸入即可加入同一個群組。'),
+          const Gap(16),
+          SelectableText(
+            code,
+            style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold, letterSpacing: 4),
+            textAlign: TextAlign.center,
+          ),
+          const Gap(8),
+          const Text('有效期限：24 小時', style: TextStyle(color: Colors.grey)),
+        ]),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: code));
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                const SnackBar(content: Text('已複製'), behavior: SnackBarBehavior.floating));
+            },
+            child: const Text('複製'),
+          ),
+          FilledButton(onPressed: () => Navigator.pop(ctx), child: const Text('關閉')),
+        ],
+      ));
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('產生邀請碼失敗：$e'), behavior: SnackBarBehavior.floating));
+      }
+    }
+  }
+
+  void _joinByInviteCode(BuildContext context, WidgetRef ref) {
+    final controller = TextEditingController();
+    showDialog(context: context, builder: (ctx) => AlertDialog(
+      title: const Text('加入群組'),
+      content: Column(mainAxisSize: MainAxisSize.min, children: [
+        const Text('輸入家人給你的邀請碼，加入同一個家庭群組。'),
+        const Gap(16),
+        TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: '6 碼邀請碼',
+            border: OutlineInputBorder(),
+          ),
+          textCapitalization: TextCapitalization.characters,
+          autofocus: true,
+        ),
+      ]),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('取消')),
+        FilledButton(onPressed: () async {
+          final code = controller.text.trim().toUpperCase();
+          if (code.isEmpty) return;
+          try {
+            final groupId = await FirebaseSyncService.joinGroupByCode(code);
+            if (!ctx.mounted) return;
+            if (groupId == null) {
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                const SnackBar(content: Text('邀請碼無效或已過期'), behavior: SnackBarBehavior.floating));
+              return;
+            }
+            // 開始監聽新群組
+            FirebaseSyncService.startRealtimeSync(groupId);
+            Navigator.pop(ctx);
+            ScaffoldMessenger.of(ctx).showSnackBar(
+              const SnackBar(content: Text('已成功加入群組！資料同步中...'), behavior: SnackBarBehavior.floating));
+          } catch (e) {
+            if (ctx.mounted) {
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                SnackBar(content: Text('加入失敗：$e'), behavior: SnackBarBehavior.floating));
+            }
+          }
+        }, child: const Text('加入')),
       ],
     ));
   }

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:isar/isar.dart';
@@ -34,9 +35,137 @@ class FirebaseSyncService {
 
   // ── 匿名登入（最簡方案，可後續升級為 Google Sign-In） ──
 
+  static StreamSubscription? _expenseListener;
+  static StreamSubscription? _settlementListener;
+  static String? _syncedGroupId;
+
   static Future<User?> signInAnonymously() async {
     final credential = await _auth.signInAnonymously();
     return credential.user;
+  }
+
+  /// 首次同步：把本地群組、成員、支出、結算上傳到 Firestore
+  static Future<void> initialSync() async {
+    if (!isSignedIn) return;
+    final isar = await DatabaseService.instance;
+    final groupId = await DatabaseService.getPrimaryGroupId();
+    if (groupId == null) return;
+
+    // 上傳群組
+    final group = await isar.familyGroups.filter().idEqualTo(groupId).findFirst();
+    if (group != null) await syncGroupUp(group);
+
+    // 上傳所有成員
+    final members = await isar.familyMembers.filter().groupIdEqualTo(groupId).findAll();
+    for (final m in members) {
+      await syncMemberUp(groupId, m);
+    }
+
+    // 上傳所有支出
+    final expenses = await isar.expenses.filter().groupIdEqualTo(groupId).findAll();
+    for (final e in expenses) {
+      await syncExpenseUp(groupId, e);
+    }
+
+    // 上傳所有結算
+    final settlements = await isar.settlements.filter().groupIdEqualTo(groupId).findAll();
+    for (final s in settlements) {
+      await syncSettlementUp(groupId, s);
+    }
+
+    // 開始即時監聽
+    startRealtimeSync(groupId);
+  }
+
+  /// 開始即時監聽 Firestore 變更（支出 + 結算）
+  static void startRealtimeSync(String groupId) {
+    if (_syncedGroupId == groupId) return; // 已在監聽
+    stopRealtimeSync();
+    _syncedGroupId = groupId;
+
+    // 監聽遠端支出變更
+    _expenseListener = _expensesRef(groupId)
+        .snapshots()
+        .listen((snapshot) async {
+      for (final change in snapshot.docChanges) {
+        if (change.type == DocumentChangeType.removed) {
+          // 遠端刪除 → 本地刪除
+          final isar = await DatabaseService.instance;
+          final local = await isar.expenses.filter().idEqualTo(change.doc.id).findFirst();
+          if (local != null) {
+            await isar.writeTxn(() async {
+              await isar.expenses.delete(local.isarId);
+            });
+          }
+        } else {
+          // 新增或修改 → merge 到本地
+          final data = change.doc.data();
+          if (data != null) {
+            await mergeExpenseFromRemote(data, change.doc.id);
+          }
+        }
+      }
+    });
+
+    // 監聽遠端結算變更
+    _settlementListener = _settlementsRef(groupId)
+        .snapshots()
+        .listen((snapshot) async {
+      for (final change in snapshot.docChanges) {
+        if (change.type == DocumentChangeType.removed) {
+          final isar = await DatabaseService.instance;
+          final local = await isar.settlements.filter().idEqualTo(change.doc.id).findFirst();
+          if (local != null) {
+            await isar.writeTxn(() async {
+              await isar.settlements.delete(local.isarId);
+            });
+          }
+        } else {
+          final data = change.doc.data();
+          if (data != null) {
+            await _mergeSettlementFromRemote(data, change.doc.id);
+          }
+        }
+      }
+    });
+  }
+
+  /// 停止即時監聽
+  static void stopRealtimeSync() {
+    _expenseListener?.cancel();
+    _settlementListener?.cancel();
+    _expenseListener = null;
+    _settlementListener = null;
+    _syncedGroupId = null;
+  }
+
+  /// 將遠端結算寫入本地 Isar
+  static Future<void> _mergeSettlementFromRemote(
+      Map<String, dynamic> data, String settlementId) async {
+    final isar = await DatabaseService.instance;
+    final local = await isar.settlements.filter().idEqualTo(settlementId).findFirst();
+    final remoteCreatedAt = (data['createdAt'] as Timestamp).toDate();
+
+    // 如果本地已有且較新，跳過
+    if (local != null && local.createdAt.isAfter(remoteCreatedAt)) return;
+
+    final settlement = Settlement()
+      ..id = settlementId
+      ..groupId = (await DatabaseService.getPrimaryGroupId()) ?? ''
+      ..fromMemberId = data['fromMemberId'] as String
+      ..fromMemberName = data['fromMemberName'] as String
+      ..toMemberId = data['toMemberId'] as String
+      ..toMemberName = data['toMemberName'] as String
+      ..amount = (data['amount'] as num).toDouble()
+      ..note = data['note'] as String?
+      ..date = (data['date'] as Timestamp).toDate()
+      ..createdAt = remoteCreatedAt;
+
+    if (local != null) settlement.isarId = local.isarId;
+
+    await isar.writeTxn(() async {
+      await isar.settlements.put(settlement);
+    });
   }
 
   // ── 群組同步 ──


### PR DESCRIPTION
## Summary
Enable real cross-device data synchronization:

### Startup flow
1. App starts → anonymous Firebase sign-in (每台裝置一個 UID)
2. Initial sync uploads local data to Firestore (idempotent)
3. Real-time Firestore listeners start for expenses + settlements

### Sync behavior
- **Local → Remote**: Every add/edit/delete in providers already calls `FirebaseSyncService` (from PR #28)
- **Remote → Local**: Firestore snapshot listeners detect changes and merge to local Isar
- **Conflict resolution**: Newer `updatedAt` / `createdAt` wins
- **Delete sync**: Firestore document removal triggers local Isar deletion

### Invite code (Settings page)
- "產生邀請碼" → 6-char code, 24h expiry, copy to clipboard
- "輸入邀請碼" → Join family group, UID added to `memberUids[]`
- After joining, real-time sync starts for the new group

Closes #43

## Test plan
- [ ] Fresh app launch → Firebase sign-in succeeds (check Console)
- [ ] Add expense on device A → appears on device B within seconds
- [ ] Delete expense on device A → removed from device B
- [ ] Generate invite code → 6-char code displayed
- [ ] Enter invite code on device B → joins group, data syncs
- [ ] Expired code (>24h) → "邀請碼無效或已過期"

🤖 Generated with [Claude Code](https://claude.com/claude-code)