### PR TITLE
feat(auth): add Apple Sign-In for multi-device sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
 import 'services/local_notification_service.dart';
 import 'services/firebase_sync_service.dart';
+import 'services/auth_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'app.dart';
@@ -20,8 +21,10 @@ void main() async {
   // 初始化 Firebase
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
-  // 匿名登入 Firebase（啟用跨裝置同步）
-  await FirebaseSyncService.signInAnonymously();
+  // 如果尚未登入，先匿名登入（使用者可稍後在設定升級為 Apple Sign-In）
+  if (!AuthService.hasAnyAuth) {
+    await AuthService.signInAnonymously();
+  }
 
   // 將本地群組上傳到 Firestore（首次同步）
   await FirebaseSyncService.initialSync();

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:gap/gap.dart';
 import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
 import '../../services/firebase_sync_service.dart';
+import '../../services/auth_service.dart';
 import '../../services/database_service.dart';
 import '../../providers/theme_provider.dart';
 import 'category_management_page.dart';
@@ -179,22 +180,57 @@ class SettingsPage extends ConsumerWidget {
             ),
           ])),
           const Gap(16),
-          // 同步設定
+          // 帳號 & 同步
           Card(child: Padding(
             padding: const EdgeInsets.all(20),
             child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Row(children: [
                 Icon(Icons.sync_outlined, color: theme.colorScheme.primary, size: 20),
                 const Gap(8),
-                Text('跨裝置同步', style: theme.textTheme.titleMedium),
+                Text('帳號與同步', style: theme.textTheme.titleMedium),
               ]),
-              const Gap(4),
-              Text(
-                FirebaseSyncService.isSignedIn ? '已連線 ✓' : '未連線',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: FirebaseSyncService.isSignedIn ? Colors.green : theme.colorScheme.error),
-              ),
-              const Gap(12),
+              const Gap(8),
+              // 帳號狀態
+              if (AuthService.isSignedIn) ...[
+                Row(children: [
+                  const Icon(Icons.check_circle, color: Colors.green, size: 16),
+                  const Gap(6),
+                  Expanded(child: Text(
+                    'Apple ID 已登入${AuthService.email != null ? '（${AuthService.email}）' : ''}',
+                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.green),
+                  )),
+                ]),
+                const Gap(4),
+                Text('多台裝置登入同一個 Apple ID 即可自動同步',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+              ] else ...[
+                Row(children: [
+                  Icon(Icons.info_outline, size: 16,
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+                  const Gap(6),
+                  Text('匿名模式（僅限本機）',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+                ]),
+                const Gap(12),
+                SizedBox(width: double.infinity, child: FilledButton.icon(
+                  icon: const Icon(Icons.apple, size: 20),
+                  label: const Text('使用 Apple ID 登入'),
+                  onPressed: () => _signInWithApple(context),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.onSurface,
+                    foregroundColor: theme.colorScheme.surface,
+                    minimumSize: const Size.fromHeight(48),
+                  ),
+                )),
+                const Gap(4),
+                Text('登入後可跨裝置同步，同 Apple ID 的所有裝置自動共享資料',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+              ],
+              const Gap(16),
+              // 邀請碼
               SizedBox(width: double.infinity, child: OutlinedButton.icon(
                 icon: const Icon(Icons.link, size: 18),
                 label: const Text('產生邀請碼（分享給家人）'),
@@ -305,6 +341,29 @@ class SettingsPage extends ConsumerWidget {
         }, child: const Text('儲存')),
       ],
     ));
+  }
+
+  void _signInWithApple(BuildContext context) async {
+    try {
+      final user = await AuthService.signInWithApple();
+      if (user == null) return;
+      // 重新同步（新 UID 可能不同）
+      await FirebaseSyncService.initialSync();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Apple ID 登入成功${user.email != null ? "（${user.email}）" : ""}'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('登入失敗：$e'), behavior: SnackBarBehavior.floating),
+        );
+      }
+    }
   }
 
   void _generateInviteCode(BuildContext context) async {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:math';
+import 'package:crypto/crypto.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+/// 認證服務（Apple Sign-In + Firebase Auth）
+class AuthService {
+  static FirebaseAuth get _auth => FirebaseAuth.instance;
+
+  /// 目前使用者
+  static User? get currentUser => _auth.currentUser;
+
+  /// 是否已登入（非匿名）
+  static bool get isSignedIn => currentUser != null && !currentUser!.isAnonymous;
+
+  /// 是否有任何登入（含匿名）
+  static bool get hasAnyAuth => currentUser != null;
+
+  /// 顯示名稱
+  static String? get displayName => currentUser?.displayName;
+
+  /// Email
+  static String? get email => currentUser?.email;
+
+  /// Apple Sign-In
+  static Future<User?> signInWithApple() async {
+    // 產生 nonce 防止 replay attack
+    final rawNonce = _generateNonce();
+    final nonce = _sha256ofString(rawNonce);
+
+    // 呼叫 Apple Sign-In
+    final appleCredential = await SignInWithApple.getAppleIDCredential(
+      scopes: [
+        AppleIDAuthorizationScopes.email,
+        AppleIDAuthorizationScopes.fullName,
+      ],
+      nonce: nonce,
+    );
+
+    // 用 Apple 的 identityToken 建立 Firebase credential
+    final oauthCredential = OAuthProvider('apple.com').credential(
+      idToken: appleCredential.identityToken,
+      rawNonce: rawNonce,
+    );
+
+    // 如果目前是匿名登入，link 到 Apple 帳號（保留原有資料）
+    UserCredential result;
+    if (currentUser != null && currentUser!.isAnonymous) {
+      try {
+        result = await currentUser!.linkWithCredential(oauthCredential);
+      } on FirebaseAuthException catch (e) {
+        if (e.code == 'credential-already-in-use') {
+          // 這個 Apple ID 已在別的裝置登入過 → 直接登入那個帳號
+          result = await _auth.signInWithCredential(oauthCredential);
+        } else {
+          rethrow;
+        }
+      }
+    } else {
+      result = await _auth.signInWithCredential(oauthCredential);
+    }
+
+    // 儲存 Apple 提供的姓名（Apple 只在第一次授權時給 name）
+    final user = result.user;
+    if (user != null && user.displayName == null) {
+      final fullName = [
+        appleCredential.familyName,
+        appleCredential.givenName,
+      ].where((n) => n != null && n.isNotEmpty).join('');
+      if (fullName.isNotEmpty) {
+        await user.updateDisplayName(fullName);
+      }
+    }
+
+    return user;
+  }
+
+  /// 匿名登入（fallback）
+  static Future<User?> signInAnonymously() async {
+    final credential = await _auth.signInAnonymously();
+    return credential.user;
+  }
+
+  /// 登出
+  static Future<void> signOut() async {
+    await _auth.signOut();
+  }
+
+  /// 監聽登入狀態變更
+  static Stream<User?> get authStateChanges => _auth.authStateChanges();
+
+  // ── 工具方法 ──
+
+  static String _generateNonce([int length = 32]) {
+    const charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(length, (_) => charset[random.nextInt(charset.length)]).join();
+  }
+
+  static String _sha256ofString(String input) {
+    final bytes = utf8.encode(input);
+    final digest = sha256.convert(bytes);
+    return digest.toString();
+  }
+}

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'auth_service.dart';
 import 'package:isar/isar.dart';
 import '../models/expense.dart';
 import '../models/family_member.dart';
@@ -25,23 +26,20 @@ import 'database_service.dart';
 /// 4. 設定 Firestore Security Rules
 class FirebaseSyncService {
   static FirebaseFirestore get _db => FirebaseFirestore.instance;
-  static FirebaseAuth get _auth => FirebaseAuth.instance;
 
   /// 目前登入的 Firebase 使用者
-  static User? get currentUser => _auth.currentUser;
+  static User? get currentUser => AuthService.currentUser;
 
-  /// 是否已登入
-  static bool get isSignedIn => currentUser != null;
-
-  // ── 匿名登入（最簡方案，可後續升級為 Google Sign-In） ──
+  /// 是否已登入（含匿名）
+  static bool get isSignedIn => AuthService.hasAnyAuth;
 
   static StreamSubscription? _expenseListener;
   static StreamSubscription? _settlementListener;
   static String? _syncedGroupId;
 
+  /// 匿名登入（舊方法，保留向下相容）
   static Future<User?> signInAnonymously() async {
-    final credential = await _auth.signInAnonymously();
-    return credential.user;
+    return await AuthService.signInAnonymously();
   }
 
   /// 首次同步：把本地群組、成員、支出、結算上傳到 Firestore

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   firebase_core: ^3.8.1
   cloud_firestore: ^5.6.5
   firebase_auth: ^5.4.3
+  sign_in_with_apple: ^6.1.4
+  crypto: ^3.0.6
 
   # 工具
   uuid: ^4.3.3


### PR DESCRIPTION
## Summary
Add Apple Sign-In for cross-device data synchronization:

### How it works
- **Same Apple ID** on iPhone + Mac → **same Firebase UID** → data auto-syncs
- **Different Apple IDs** (family members) → different UIDs → join via invite code

### Technical details
- `AuthService` wraps sign_in_with_apple + Firebase Auth
- Anonymous → Apple account linking (preserves existing Isar data)
- Handles credential-already-in-use (signs into existing account on new device)
- SHA-256 nonce for replay attack prevention
- Settings page shows Apple Sign-In button (anonymous) or account status (signed in)

### User flow
1. First launch → anonymous login (works offline)
2. Settings → "使用 Apple ID 登入" → Apple auth sheet
3. Second device → same Apple ID → same data

Closes #45

## Before using
1. **Firebase Console** → Authentication → 登入方式 → 啟用 **Apple**
2. **Apple Developer** → Certificates → 啟用 Sign In with Apple capability
3. **Xcode** → Runner target → Signing & Capabilities → + Sign In with Apple

## Test plan
- [ ] Anonymous user sees Apple Sign-In button in settings
- [ ] Tap → Apple auth sheet → successful login
- [ ] Settings shows "Apple ID 已登入" with email
- [ ] Second device with same Apple ID → data syncs
- [ ] Anonymous data preserved after linking to Apple

🤖 Generated with [Claude Code](https://claude.com/claude-code)