### PR TITLE
feat(auth): add Google Sign-In, hide Apple Sign-In

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,6 +34,18 @@
 	<string>從相簿選擇收據或發票照片以附加到支出記錄</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>語音記帳需要語音辨識來將語音轉為文字</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<!-- TODO: 從 GoogleService-Info.plist 的 REVERSED_CLIENT_ID 取得 -->
+				<string>com.googleusercontent.apps.137558877215-PLACEHOLDER</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -196,12 +196,12 @@ class SettingsPage extends ConsumerWidget {
                   const Icon(Icons.check_circle, color: Colors.green, size: 16),
                   const Gap(6),
                   Expanded(child: Text(
-                    'Apple ID 已登入${AuthService.email != null ? '（${AuthService.email}）' : ''}',
+                    '已登入${AuthService.email != null ? '（${AuthService.email}）' : ''}',
                     style: theme.textTheme.bodySmall?.copyWith(color: Colors.green),
                   )),
                 ]),
                 const Gap(4),
-                Text('多台裝置登入同一個 Apple ID 即可自動同步',
+                Text('多台裝置登入同一個帳號即可自動同步',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
               ] else ...[
@@ -215,17 +215,22 @@ class SettingsPage extends ConsumerWidget {
                 ]),
                 const Gap(12),
                 SizedBox(width: double.infinity, child: FilledButton.icon(
-                  icon: const Icon(Icons.apple, size: 20),
-                  label: const Text('使用 Apple ID 登入'),
-                  onPressed: () => _signInWithApple(context),
+                  icon: Image.network(
+                    'https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg',
+                    width: 20, height: 20,
+                    errorBuilder: (_, __, ___) => const Icon(Icons.g_mobiledata, size: 20),
+                  ),
+                  label: const Text('使用 Google 帳號登入'),
+                  onPressed: () => _signInWithGoogle(context),
                   style: FilledButton.styleFrom(
-                    backgroundColor: theme.colorScheme.onSurface,
-                    foregroundColor: theme.colorScheme.surface,
+                    backgroundColor: Colors.white,
+                    foregroundColor: Colors.black87,
                     minimumSize: const Size.fromHeight(48),
+                    side: BorderSide(color: Colors.grey.shade300),
                   ),
                 )),
                 const Gap(4),
-                Text('登入後可跨裝置同步，同 Apple ID 的所有裝置自動共享資料',
+                Text('登入後可跨裝置同步，同一帳號的所有裝置自動共享資料',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
               ],
@@ -343,16 +348,16 @@ class SettingsPage extends ConsumerWidget {
     ));
   }
 
-  void _signInWithApple(BuildContext context) async {
+  void _signInWithGoogle(BuildContext context) async {
     try {
-      final user = await AuthService.signInWithApple();
-      if (user == null) return;
+      final user = await AuthService.signInWithGoogle();
+      if (user == null) return; // 使用者取消
       // 重新同步（新 UID 可能不同）
       await FirebaseSyncService.initialSync();
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Apple ID 登入成功${user.email != null ? "（${user.email}）" : ""}'),
+            content: Text('Google 登入成功${user.email != null ? "（${user.email}）" : ""}'),
             behavior: SnackBarBehavior.floating,
           ),
         );

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -2,9 +2,10 @@ import 'dart:convert';
 import 'dart:math';
 import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
-/// 認證服務（Apple Sign-In + Firebase Auth）
+/// 認證服務（Google Sign-In / Apple Sign-In + Firebase Auth）
 class AuthService {
   static FirebaseAuth get _auth => FirebaseAuth.instance;
 
@@ -74,6 +75,37 @@ class AuthService {
     }
 
     return user;
+  }
+
+  /// Google Sign-In
+  static Future<User?> signInWithGoogle() async {
+    final googleUser = await GoogleSignIn(scopes: ['email']).signIn();
+    if (googleUser == null) return null; // 使用者取消
+
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+
+    // 如果目前是匿名登入，link 到 Google 帳號（保留原有資料）
+    UserCredential result;
+    if (currentUser != null && currentUser!.isAnonymous) {
+      try {
+        result = await currentUser!.linkWithCredential(credential);
+      } on FirebaseAuthException catch (e) {
+        if (e.code == 'credential-already-in-use') {
+          // 這個 Google 帳號已在別的裝置登入過 → 直接登入那個帳號
+          result = await _auth.signInWithCredential(credential);
+        } else {
+          rethrow;
+        }
+      }
+    } else {
+      result = await _auth.signInWithCredential(credential);
+    }
+
+    return result.user;
   }
 
   /// 匿名登入（fallback）

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   cloud_firestore: ^5.6.5
   firebase_auth: ^5.4.3
   sign_in_with_apple: ^6.1.4
+  google_sign_in: ^6.2.2
   crypto: ^3.0.6
 
   # 工具


### PR DESCRIPTION
## Summary
- Add Google Sign-In (免付費 Apple Developer Program)
- Hide Apple Sign-In button (code preserved for future use)
- Same anonymous→linked account flow: existing data preserved when upgrading
- Settings page shows Google-branded login button

Closes #47

## Firebase Console setup required
1. **Authentication** → 登入方式 → 啟用 **Google**
2. 下載更新後的 `GoogleService-Info.plist`（會包含 CLIENT_ID）
3. 更新 `ios/Runner/Info.plist` 中的 URL scheme placeholder

## Test plan
- [ ] Settings shows Google sign-in button (anonymous state)
- [ ] Tap → Google auth sheet → successful login
- [ ] Settings shows "已登入（email）"
- [ ] Second device with same Google → data syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)