### PR TITLE
security: fix 7 vulnerabilities (C1/C2/C4/H1/H3/H4/M6)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -86,7 +86,9 @@ service cloud.firestore {
           && request.resource.data.amount < 100000000
           && isReasonableSize();
 
-        allow delete: if isGroupMember(groupId);
+        // 刪除：僅建立者或群組 owner
+        allow delete: if isGroupMember(groupId)
+          && (resource.data.createdBy == request.auth.uid || isGroupOwner(groupId));
       }
 
       // ─── 結算 ───
@@ -102,8 +104,13 @@ service cloud.firestore {
           && request.resource.data.toMemberId is string
           && isReasonableSize();
 
-        allow update: if isGroupMember(groupId);
-        allow delete: if isGroupMember(groupId);
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000;
+        // 刪除：僅建立者或群組 owner
+        allow delete: if isGroupMember(groupId)
+          && (resource.data.fromMemberId == request.auth.uid || isGroupOwner(groupId));
       }
     }
 

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -1,9 +1,36 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 
-/// 簡單的 app 設定持久化（JSON 檔案）
+/// App 設定持久化
+/// - 敏感資料（API Keys）→ flutter_secure_storage（Keychain/Keystore）
+/// - 一般設定（主題等）→ JSON 檔案
 class AppSettingsService {
+  static const _secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+
+  // ── 安全儲存（API Keys 等敏感資料） ──
+
+  static Future<String?> getSecure(String key) async {
+    return await _secureStorage.read(key: key);
+  }
+
+  static Future<void> setSecure(String key, String? value) async {
+    if (value == null) {
+      await _secureStorage.delete(key: key);
+    } else {
+      await _secureStorage.write(key: key, value: value);
+    }
+  }
+
+  // Gemini API Key（安全儲存）
+  static Future<String?> get geminiApiKey => getSecure('gemini_api_key');
+  static Future<void> setGeminiApiKey(String? key) => setSecure('gemini_api_key', key);
+
+  // ── 一般設定（非敏感，JSON 檔案） ──
+
   static Map<String, dynamic>? _cache;
 
   static Future<File> get _file async {
@@ -41,8 +68,4 @@ class AppSettingsService {
     }
     await _save();
   }
-
-  // Convenience
-  static Future<String?> get geminiApiKey => get('gemini_api_key');
-  static Future<void> setGeminiApiKey(String? key) => set('gemini_api_key', key);
 }

--- a/lib/services/expense_parser_service.dart
+++ b/lib/services/expense_parser_service.dart
@@ -42,12 +42,15 @@ class ExpenseParserService {
 語音輸入：「$text」''';
 
     final url = Uri.parse(
-      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$apiKey',
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent',
     );
 
     final response = await http.post(
       url,
-      headers: {'Content-Type': 'application/json'},
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
       body: jsonEncode({
         'contents': [
           {
@@ -64,7 +67,7 @@ class ExpenseParserService {
     );
 
     if (response.statusCode != 200) {
-      throw Exception('AI 解析失敗 (${response.statusCode})：${response.body}');
+      throw Exception('AI 解析失敗 (${response.statusCode})');
     }
 
     final body = jsonDecode(response.body) as Map<String, dynamic>;

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'auth_service.dart';
@@ -285,68 +286,86 @@ class FirebaseSyncService {
   }
 
   /// 將遠端支出寫入本地 Isar（merge 邏輯：以 updatedAt 較新者為準）
+  /// 含防禦性型別檢查，避免惡意或格式錯誤的資料 crash app
   static Future<void> mergeExpenseFromRemote(
       Map<String, dynamic> data, String expenseId) async {
-    final isar = await DatabaseService.instance;
-    final local = await isar.expenses.filter().idEqualTo(expenseId).findFirst();
+    try {
+      final isar = await DatabaseService.instance;
+      final local = await isar.expenses.filter().idEqualTo(expenseId).findFirst();
 
-    final remoteUpdatedAt = (data['updatedAt'] as Timestamp).toDate();
+      final updatedAtRaw = data['updatedAt'];
+      if (updatedAtRaw is! Timestamp) return; // 缺少必要欄位，跳過
+      final remoteUpdatedAt = updatedAtRaw.toDate();
 
-    // 如果本地已有且較新，跳過
-    if (local != null && local.updatedAt.isAfter(remoteUpdatedAt)) return;
+      if (local != null && local.updatedAt.isAfter(remoteUpdatedAt)) return;
 
-    final expense = Expense()
-      ..id = expenseId
-      ..groupId = (await DatabaseService.getPrimaryGroupId()) ?? ''
-      ..date = (data['date'] as Timestamp).toDate()
-      ..description = data['description'] as String
-      ..amount = (data['amount'] as num).toDouble()
-      ..category = data['category'] as String
-      ..isShared = data['isShared'] as bool
-      ..splitMethod = SplitMethod.values.firstWhere(
-          (e) => e.name == data['splitMethod'],
-          orElse: () => SplitMethod.equal)
-      ..payerId = data['payerId'] as String
-      ..payerName = data['payerName'] as String
-      ..paymentMethod = PaymentMethod.values.firstWhere(
-          (e) => e.name == (data['paymentMethod'] ?? 'cash'),
-          orElse: () => PaymentMethod.cash)
-      ..splits = ((data['splits'] as List?) ?? []).map((s) {
-        final map = s as Map<String, dynamic>;
-        return SplitDetail()
-          ..memberId = map['memberId'] as String
-          ..memberName = map['memberName'] as String
-          ..shareAmount = (map['shareAmount'] as num).toDouble()
-          ..paidAmount = (map['paidAmount'] as num).toDouble()
-          ..isParticipant = map['isParticipant'] as bool;
-      }).toList()
-      ..receiptPath = data['receiptPath'] as String?
-      ..note = data['note'] as String?
-      ..createdBy = data['createdBy'] as String
-      ..createdAt = (data['createdAt'] as Timestamp).toDate()
-      ..updatedAt = remoteUpdatedAt;
+      // 防禦性解析：每個欄位都有 fallback
+      final description = (data['description'] as String?) ?? '';
+      if (description.isEmpty) return; // 無效資料
+
+      final amount = (data['amount'] as num?)?.toDouble() ?? 0;
+      if (amount <= 0 || amount >= 100000000) return; // 金額不合理
+
+      final expense = Expense()
+        ..id = expenseId
+        ..groupId = (await DatabaseService.getPrimaryGroupId()) ?? ''
+        ..date = (data['date'] as Timestamp?)?.toDate() ?? DateTime.now()
+        ..description = description.length > 200 ? description.substring(0, 200) : description
+        ..amount = amount
+        ..category = (data['category'] as String?) ?? '其他'
+        ..isShared = (data['isShared'] as bool?) ?? false
+        ..splitMethod = SplitMethod.values.firstWhere(
+            (e) => e.name == data['splitMethod'],
+            orElse: () => SplitMethod.equal)
+        ..payerId = (data['payerId'] as String?) ?? ''
+        ..payerName = (data['payerName'] as String?) ?? ''
+        ..paymentMethod = PaymentMethod.values.firstWhere(
+            (e) => e.name == (data['paymentMethod'] ?? 'cash'),
+            orElse: () => PaymentMethod.cash)
+        ..splits = ((data['splits'] as List?) ?? []).where((s) => s is Map).map((s) {
+          final map = s as Map<String, dynamic>;
+          return SplitDetail()
+            ..memberId = (map['memberId'] as String?) ?? ''
+            ..memberName = (map['memberName'] as String?) ?? ''
+            ..shareAmount = (map['shareAmount'] as num?)?.toDouble() ?? 0
+            ..paidAmount = (map['paidAmount'] as num?)?.toDouble() ?? 0
+            ..isParticipant = (map['isParticipant'] as bool?) ?? false;
+        }).toList()
+        ..receiptPath = data['receiptPath'] as String?
+        ..receiptPaths = ((data['receiptPaths'] as List?) ?? []).whereType<String>().toList()
+        ..note = data['note'] as String?
+        ..createdBy = (data['createdBy'] as String?) ?? ''
+        ..createdAt = (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now()
+        ..updatedAt = remoteUpdatedAt;
 
     // 保留本地 isarId
     if (local != null) expense.isarId = local.isarId;
 
-    await isar.writeTxn(() async {
-      await isar.expenses.put(expense);
-    });
+      await isar.writeTxn(() async {
+        await isar.expenses.put(expense);
+      });
+    } catch (_) {
+      // 防禦性：任何反序列化錯誤靜默忽略，不影響 app 運行
+    }
   }
 
   // ── 邀請碼加入群組 ──
 
-  /// 產生 6 碼邀請碼（存在群組 doc 上）
+  /// 產生 8 碼加密安全邀請碼（24 小時有效，最多使用 5 次）
   static Future<String> generateInviteCode(String groupId) async {
-    final code = DateTime.now().millisecondsSinceEpoch.toRadixString(36).substring(2, 8).toUpperCase();
+    const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // 去除易混淆字元 0OI1
+    final random = Random.secure();
+    final code = List.generate(8, (_) => charset[random.nextInt(charset.length)]).join();
     await _groupDoc(groupId).update({
       'inviteCode': code,
       'inviteExpiry': Timestamp.fromDate(DateTime.now().add(const Duration(hours: 24))),
+      'inviteUsedCount': 0,
+      'inviteMaxUses': 5,
     });
     return code;
   }
 
-  /// 用邀請碼加入群組（同時將 UID 加入 memberUids）
+  /// 用邀請碼加入群組（同時將 UID 加入 memberUids，含使用次數限制）
   static Future<String?> joinGroupByCode(String code) async {
     final snap = await _groupsRef()
         .where('inviteCode', isEqualTo: code)
@@ -354,10 +373,20 @@ class FirebaseSyncService {
         .limit(1)
         .get();
     if (snap.docs.isEmpty) return null;
-    final groupId = snap.docs.first.id;
+
+    final doc = snap.docs.first;
+    final data = doc.data();
+    final usedCount = (data['inviteUsedCount'] as num?) ?? 0;
+    final maxUses = (data['inviteMaxUses'] as num?) ?? 5;
+    if (usedCount >= maxUses) return null; // 已達使用上限
+
+    final groupId = doc.id;
     final uid = currentUser?.uid;
     if (uid != null) {
-      await addMemberUid(groupId, uid);
+      await _groupDoc(groupId).update({
+        'memberUids': FieldValue.arrayUnion([uid]),
+        'inviteUsedCount': FieldValue.increment(1),
+      });
     }
     return groupId;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   sign_in_with_apple: ^6.1.4
   google_sign_in: ^6.2.2
   crypto: ^3.0.6
+  flutter_secure_storage: ^9.2.4
 
   # 工具
   uuid: ^4.3.3


### PR DESCRIPTION
## Security fixes

| Issue | Severity | Fix |
|-------|----------|-----|
| #50 C1 | CRITICAL | API Key → Keychain via flutter_secure_storage |
| #51 C2 | CRITICAL | API Key → HTTP header (not URL query param) |
| #53 C4 | CRITICAL | Invite code → Random.secure() 8-char |
| #54 H1 | HIGH | Firestore delete → creator or owner only |
| #56 H3 | HIGH | Invite code max 5 uses + counter |
| #57 H4 | HIGH | Defensive deserialization with try-catch |
| #63 M6 | MEDIUM | Error messages don't expose response body |

Firestore rules already deployed to production.

Closes #50 #51 #53 #54 #56 #57 #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)