### PR TITLE
security: fix remaining 6 issues (C3/H2/M1-M5)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,8 +30,9 @@ service cloud.firestore {
 
     match /groups/{groupId} {
 
-      // 讀取：僅群組成員
-      allow read: if isGroupMember(groupId);
+      // 讀取：群組成員，或已登入使用者透過邀請碼查詢（list query）
+      allow read: if isGroupMember(groupId)
+        || (isSignedIn() && resource.data.inviteCode != null);
 
       // 建立：任何已登入使用者（建群組）
       // 必須包含 ownerUid = 自己，且 memberUids 包含自己
@@ -59,8 +60,11 @@ service cloud.firestore {
           && request.resource.data.name is string
           && request.resource.data.name.size() > 0
           && request.resource.data.name.size() <= 30;
-        allow update: if isGroupMember(groupId);
-        allow delete: if isGroupMember(groupId);
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.name is string
+          && request.resource.data.name.size() > 0
+          && request.resource.data.name.size() <= 30;
+        allow delete: if isGroupOwner(groupId);
       }
 
       // ─── 支出 ───

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'services/local_notification_service.dart';
 import 'services/firebase_sync_service.dart';
 import 'services/auth_service.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'firebase_options.dart';
 import 'app.dart';
 
@@ -21,13 +22,21 @@ void main() async {
   // 初始化 Firebase
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
-  // 如果尚未登入，先匿名登入（使用者可稍後在設定升級為 Apple Sign-In）
+  // 啟用 App Check 防止 API 濫用（僅合法 app 可存取 Firebase）
+  await FirebaseAppCheck.instance.activate(
+    appleProvider: AppleProvider.deviceCheck,
+    androidProvider: AndroidProvider.playIntegrity,
+  );
+
+  // 如果尚未登入，先匿名登入（使用者可稍後在設定升級為 Google Sign-In）
   if (!AuthService.hasAnyAuth) {
     await AuthService.signInAnonymously();
   }
 
-  // 將本地群組上傳到 Firestore（首次同步）
-  await FirebaseSyncService.initialSync();
+  // 僅在已登入（非匿名）時才同步到 Firestore（#59 M2）
+  if (AuthService.isSignedIn) {
+    await FirebaseSyncService.initialSync();
+  }
 
   // 初始化本地推播通知
   await LocalNotificationService.init();

--- a/lib/services/expense_parser_service.dart
+++ b/lib/services/expense_parser_service.dart
@@ -85,14 +85,23 @@ class ExpenseParserService {
 
     final parsed = jsonDecode(cleaned) as Map<String, dynamic>;
 
-    // Validate and sanitize
+    // Validate and sanitize（#58 M1: 長度限制 + 範圍驗證）
+    var desc = (parsed['description'] as String?)?.trim() ?? text;
+    if (desc.length > 200) desc = desc.substring(0, 200);
+
+    var amount = (parsed['amount'] is num) ? (parsed['amount'] as num).toDouble() : 0.0;
+    if (amount < 0 || amount >= 100000000) amount = 0.0;
+
+    final dateStr = parsed['date'] as String? ?? today;
+    final validDate = RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(dateStr) ? dateStr : today;
+
     return {
-      'description': (parsed['description'] as String?)?.trim() ?? text,
-      'amount': (parsed['amount'] is num) ? (parsed['amount'] as num).toDouble() : 0.0,
+      'description': desc,
+      'amount': amount,
       'category': availableCategories.contains(parsed['category'])
           ? parsed['category']
           : availableCategories.first,
-      'date': parsed['date'] as String? ?? today,
+      'date': validDate,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   google_sign_in: ^6.2.2
   crypto: ^3.0.6
   flutter_secure_storage: ^9.2.4
+  firebase_app_check: ^0.3.2+5
 
   # 工具
   uuid: ^4.3.3


### PR DESCRIPTION
## Security fixes

| Issue | Fix |
|-------|-----|
| #52 C3 + #62 M5 | Firebase App Check (DeviceCheck + PlayIntegrity) |
| #55 H2 | Firestore Rules: invite code query exception for signed-in users |
| #58 M1 | LLM response: desc ≤200 chars, amount 0–100M, date YYYY-MM-DD |
| #59 M2 | Anonymous users don't auto-sync (sync triggers on Google login only) |
| #60 M3 | Members: update requires name validation, delete requires owner |

#61 M4 (receipt photos → Firebase Storage) deferred — requires separate Storage integration.

Closes #52 #55 #58 #59 #60 #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)