### PR TITLE
fix: App Check debug provider prevents black screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'services/local_notification_service.dart';
 import 'services/firebase_sync_service.dart';
 import 'services/auth_service.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'firebase_options.dart';
 import 'app.dart';
@@ -22,20 +23,24 @@ void main() async {
   // 初始化 Firebase
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
-  // 啟用 App Check 防止 API 濫用（僅合法 app 可存取 Firebase）
+  // 啟用 App Check 防止 API 濫用
+  // Debug/本機 build 使用 debug provider，App Store release 才用 deviceCheck
   await FirebaseAppCheck.instance.activate(
-    appleProvider: AppleProvider.deviceCheck,
-    androidProvider: AndroidProvider.playIntegrity,
+    appleProvider: kDebugMode ? AppleProvider.debug : AppleProvider.deviceCheck,
+    androidProvider: kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
   );
 
   // 如果尚未登入，先匿名登入（使用者可稍後在設定升級為 Google Sign-In）
-  if (!AuthService.hasAnyAuth) {
-    await AuthService.signInAnonymously();
-  }
-
-  // 僅在已登入（非匿名）時才同步到 Firestore（#59 M2）
-  if (AuthService.isSignedIn) {
-    await FirebaseSyncService.initialSync();
+  try {
+    if (!AuthService.hasAnyAuth) {
+      await AuthService.signInAnonymously();
+    }
+    // 僅在已登入（非匿名）時才同步到 Firestore
+    if (AuthService.isSignedIn) {
+      await FirebaseSyncService.initialSync();
+    }
+  } catch (_) {
+    // Firebase 初始化失敗不阻擋 app 啟動（離線模式可用）
   }
 
   // 初始化本地推播通知


### PR DESCRIPTION
DeviceCheck returns 403 on non-App-Store builds, causing black screen. Use debug provider in kDebugMode + wrap Firebase init in try-catch.