### PR TITLE
fix(macos): add Keychain access for Firebase Auth

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.familyledger.familyLedger</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.familyledger.familyLedger</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Firebase Auth needs Keychain to store tokens. Fixes silent auth failure and Google Sign-In not working on macOS.