### PR TITLE
feat(auth): force Google login before accessing data

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'providers/theme_provider.dart';
+import 'services/auth_service.dart';
+import 'screens/auth/login_page.dart';
 import 'screens/home/home_page.dart';
 import 'screens/split/split_overview_page.dart';
 import 'screens/records/records_page.dart';
@@ -21,7 +23,7 @@ class FamilyLedgerApp extends ConsumerWidget {
       theme: _buildTheme(settings.theme.lightSeed, Brightness.light),
       darkTheme: _buildTheme(settings.theme.darkSeed, Brightness.dark),
       themeMode: settings.mode,
-      home: const MainShell(),
+      home: const _AuthGate(),
     );
   }
 
@@ -51,6 +53,27 @@ class FamilyLedgerApp extends ConsumerWidget {
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       ),
     );
+  }
+}
+
+/// 認證閘門：未登入 Google → 登入頁，已登入 → 主畫面
+class _AuthGate extends StatefulWidget {
+  const _AuthGate();
+  @override
+  State<_AuthGate> createState() => _AuthGateState();
+}
+
+class _AuthGateState extends State<_AuthGate> {
+  bool _isLoggedIn = AuthService.isSignedIn;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isLoggedIn) {
+      return LoginPage(
+        onLoginSuccess: () => setState(() => _isLoggedIn = true),
+      );
+    }
+    return const MainShell();
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,17 +30,13 @@ void main() async {
     androidProvider: kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
   );
 
-  // 如果尚未登入，先匿名登入（使用者可稍後在設定升級為 Google Sign-In）
+  // 已登入 Google → 自動同步
   try {
-    if (!AuthService.hasAnyAuth) {
-      await AuthService.signInAnonymously();
-    }
-    // 僅在已登入（非匿名）時才同步到 Firestore
     if (AuthService.isSignedIn) {
       await FirebaseSyncService.initialSync();
     }
   } catch (_) {
-    // Firebase 初始化失敗不阻擋 app 啟動（離線模式可用）
+    // 同步失敗不阻擋 app 啟動
   }
 
   // 初始化本地推播通知

--- a/lib/screens/auth/login_page.dart
+++ b/lib/screens/auth/login_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import '../../services/auth_service.dart';
+import '../../services/firebase_sync_service.dart';
+
+/// 登入頁面（未登入 Google 前不能使用 app）
+class LoginPage extends StatefulWidget {
+  final VoidCallback onLoginSuccess;
+  const LoginPage({super.key, required this.onLoginSuccess});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  bool _isLoading = false;
+  String? _error;
+
+  Future<void> _signIn() async {
+    setState(() { _isLoading = true; _error = null; });
+    try {
+      final user = await AuthService.signInWithGoogle();
+      if (user == null) {
+        setState(() { _isLoading = false; });
+        return; // 使用者取消
+      }
+      // 登入成功，同步資料
+      await FirebaseSyncService.initialSync();
+      widget.onLoginSuccess();
+    } catch (e) {
+      setState(() { _isLoading = false; _error = '$e'; });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.account_balance_wallet,
+                  size: 80, color: theme.colorScheme.primary),
+              const Gap(24),
+              Text('家計本', style: theme.textTheme.headlineLarge?.copyWith(
+                  fontWeight: FontWeight.bold, color: theme.colorScheme.primary)),
+              const Gap(8),
+              Text('全家人共享記帳．自動拆帳．一目了然誰欠誰',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6)),
+                  textAlign: TextAlign.center),
+              const Gap(48),
+              if (_isLoading)
+                const CircularProgressIndicator()
+              else
+                SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: FilledButton.icon(
+                    icon: const Icon(Icons.g_mobiledata, size: 24),
+                    label: const Text('使用 Google 帳號登入', style: TextStyle(fontSize: 16)),
+                    onPressed: _signIn,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: Colors.black87,
+                      side: BorderSide(color: Colors.grey.shade300),
+                    ),
+                  ),
+                ),
+              if (_error != null) ...[
+                const Gap(16),
+                Text(_error!, style: TextStyle(color: theme.colorScheme.error, fontSize: 13),
+                    textAlign: TextAlign.center),
+              ],
+              const Gap(24),
+              Text('登入後可在多台裝置間同步資料',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.4)),
+                  textAlign: TextAlign.center),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -6,6 +6,8 @@ import '../../providers/member_provider.dart';
 import '../../services/app_settings_service.dart';
 import '../../services/firebase_sync_service.dart';
 import '../../services/auth_service.dart';
+import '../auth/login_page.dart';
+import '../../app.dart';
 import '../../services/database_service.dart';
 import '../../providers/theme_provider.dart';
 import 'category_management_page.dart';
@@ -180,72 +182,34 @@ class SettingsPage extends ConsumerWidget {
             ),
           ])),
           const Gap(16),
-          // 帳號 & 同步
+          // 帳號
           Card(child: Padding(
             padding: const EdgeInsets.all(20),
             child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Row(children: [
-                Icon(Icons.sync_outlined, color: theme.colorScheme.primary, size: 20),
+                Icon(Icons.account_circle_outlined, color: theme.colorScheme.primary, size: 20),
                 const Gap(8),
-                Text('帳號與同步', style: theme.textTheme.titleMedium),
+                Text('帳號', style: theme.textTheme.titleMedium),
               ]),
               const Gap(8),
-              // 帳號狀態
-              if (AuthService.isSignedIn) ...[
-                Row(children: [
-                  const Icon(Icons.check_circle, color: Colors.green, size: 16),
-                  const Gap(6),
-                  Expanded(child: Text(
-                    '已登入${AuthService.email != null ? '（${AuthService.email}）' : ''}',
-                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.green),
-                  )),
-                ]),
-                const Gap(4),
-                Text('多台裝置登入同一個帳號即可自動同步',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
-              ] else ...[
-                Row(children: [
-                  Icon(Icons.info_outline, size: 16,
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
-                  const Gap(6),
-                  Text('匿名模式（僅限本機）',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
-                ]),
-                const Gap(12),
-                SizedBox(width: double.infinity, child: FilledButton.icon(
-                  icon: Image.network(
-                    'https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg',
-                    width: 20, height: 20,
-                    errorBuilder: (_, __, ___) => const Icon(Icons.g_mobiledata, size: 20),
-                  ),
-                  label: const Text('使用 Google 帳號登入'),
-                  onPressed: () => _signInWithGoogle(context),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: Colors.black87,
-                    minimumSize: const Size.fromHeight(48),
-                    side: BorderSide(color: Colors.grey.shade300),
-                  ),
+              Row(children: [
+                const Icon(Icons.check_circle, color: Colors.green, size: 16),
+                const Gap(6),
+                Expanded(child: Text(
+                  '已登入${AuthService.email != null ? '（${AuthService.email}）' : ''}',
+                  style: theme.textTheme.bodySmall?.copyWith(color: Colors.green),
                 )),
-                const Gap(4),
-                Text('登入後可跨裝置同步，同一帳號的所有裝置自動共享資料',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
-              ],
-              const Gap(16),
-              // 邀請碼
+              ]),
+              const Gap(4),
+              Text('多台裝置登入同一個帳號即可自動同步',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.5))),
+              const Gap(12),
               SizedBox(width: double.infinity, child: OutlinedButton.icon(
-                icon: const Icon(Icons.link, size: 18),
-                label: const Text('產生邀請碼（分享給家人）'),
-                onPressed: () => _generateInviteCode(context),
-              )),
-              const Gap(8),
-              SizedBox(width: double.infinity, child: OutlinedButton.icon(
-                icon: const Icon(Icons.input, size: 18),
-                label: const Text('輸入邀請碼（加入群組）'),
-                onPressed: () => _joinByInviteCode(context, ref),
+                icon: const Icon(Icons.logout, size: 18),
+                label: const Text('登出'),
+                onPressed: () => _signOut(context),
+                style: OutlinedButton.styleFrom(foregroundColor: theme.colorScheme.error),
               )),
             ]),
           )),
@@ -348,28 +312,34 @@ class SettingsPage extends ConsumerWidget {
     ));
   }
 
-  void _signInWithGoogle(BuildContext context) async {
-    try {
-      final user = await AuthService.signInWithGoogle();
-      if (user == null) return; // 使用者取消
-      // 重新同步（新 UID 可能不同）
-      await FirebaseSyncService.initialSync();
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Google 登入成功${user.email != null ? "（${user.email}）" : ""}'),
-            behavior: SnackBarBehavior.floating,
+  void _signOut(BuildContext context) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('登出'),
+        content: const Text('登出後將無法存取資料，確定要登出嗎？'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('取消')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
+            child: const Text('登出'),
           ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('登入失敗：$e'), behavior: SnackBarBehavior.floating),
-        );
-      }
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    await AuthService.signOut();
+    if (context.mounted) {
+      // 回到登入頁
+      Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const _LoggedOutPage()),
+        (route) => false,
+      );
     }
   }
+
+  // ── 以下方法保留但不再在 UI 中顯示 ──
 
   void _generateInviteCode(BuildContext context) async {
     final groupId = await DatabaseService.getPrimaryGroupId();
@@ -478,5 +448,21 @@ class SettingsPage extends ConsumerWidget {
         ),
       ],
     ));
+  }
+}
+
+/// 登出後顯示的頁面（重新登入）
+class _LoggedOutPage extends StatelessWidget {
+  const _LoggedOutPage();
+  @override
+  Widget build(BuildContext context) {
+    return LoginPage(
+      onLoginSuccess: () {
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const ProviderScope(child: FamilyLedgerApp())),
+          (route) => false,
+        );
+      },
+    );
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -77,9 +77,14 @@ class AuthService {
     return user;
   }
 
-  /// Google Sign-In
+  /// Google Sign-In（含 serverClientId 給 iOS/macOS 使用）
   static Future<User?> signInWithGoogle() async {
-    final googleUser = await GoogleSignIn(scopes: ['email']).signIn();
+    final googleSignIn = GoogleSignIn(
+      scopes: ['email'],
+      serverClientId: '137558877215-85ak3t2lbne5iuad4aoop4fadn2m4p7u.apps.googleusercontent.com',
+    );
+
+    final googleUser = await googleSignIn.signIn();
     if (googleUser == null) return null; // 使用者取消
 
     final googleAuth = await googleUser.authentication;
@@ -88,14 +93,13 @@ class AuthService {
       idToken: googleAuth.idToken,
     );
 
-    // 如果目前是匿名登入，link 到 Google 帳號（保留原有資料）
+    // 如果目前是匿名登入，先嘗試 link（保留原有資料）
     UserCredential result;
     if (currentUser != null && currentUser!.isAnonymous) {
       try {
         result = await currentUser!.linkWithCredential(credential);
       } on FirebaseAuthException catch (e) {
         if (e.code == 'credential-already-in-use') {
-          // 這個 Google 帳號已在別的裝置登入過 → 直接登入那個帳號
           result = await _auth.signInWithCredential(credential);
         } else {
           rethrow;


### PR DESCRIPTION
## Summary
- App opens to login page — no data visible until Google signed in
- Remove anonymous auto-login
- Remove invite code buttons from settings
- Settings shows account info + logout button
- Fix Google Sign-In serverClientId for iOS/macOS

Closes #72

## Test plan
- [ ] App launch → login page (not main shell)
- [ ] Tap Google login → auth flow → main shell with data
- [ ] Settings → shows email + logout
- [ ] Logout → back to login page
- [ ] No invite code buttons visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)