### PR TITLE
fix(test): update smoke test for login-first auth flow

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,9 +1,13 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:family_ledger/app.dart';
+import 'package:family_ledger/screens/auth/login_page.dart';
 
 void main() {
-  testWidgets('App smoke test', (WidgetTester tester) async {
-    await tester.pumpWidget(const FamilyLedgerApp());
-    expect(find.text('首頁'), findsOneWidget);
+  testWidgets('Login page smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: LoginPage(onLoginSuccess: () {}),
+    ));
+    expect(find.text('家計本'), findsOneWidget);
+    expect(find.text('使用 Google 帳號登入'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Update widget test to test LoginPage instead of FamilyLedgerApp (which now requires Firebase Auth). 26/26 tests passing.