### PR TITLE
docs: sync CLAUDE.md and firebase-setup.md with current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ flutter analyze                                              # Lint check
 flutter test                                                 # Run all tests
 flutter test test/local_parser_test.dart                     # Run single test file
 firebase deploy --only firestore:rules                       # Deploy Firestore security rules
+firebase deploy --only storage                               # Deploy Storage security rules
 ```
 
 **Critical**: After ANY change to `@collection` or `@embedded` model classes, re-run `build_runner` before building. The `.g.dart` files are gitignored.
 
 **Xcode install fallback**: `flutter run` to physical iPhone often times out. Use Xcode directly: `open ios/Runner.xcworkspace` → select device → Run (Cmd+R).
+
+**macOS build**: Must use Xcode (`open macos/Runner.xcworkspace` → Run) for proper code signing. `flutter build macos` produces unsigned app that fails Keychain access.
 
 ## Architecture
 
@@ -25,7 +28,7 @@ firebase deploy --only firestore:rules                       # Deploy Firestore 
 - **Flutter 3.41+** / Dart 3.11+ with Material 3
 - **Riverpod** (flutter_riverpod) — state management
 - **Isar 3.1** — local embedded NoSQL database (source of truth)
-- **Firebase** — Firestore sync + Auth (Apple Sign-In + anonymous)
+- **Firebase** — Firestore sync + Auth (Google Sign-In mandatory) + Storage (receipts)
 - **speech_to_text** — on-device voice recognition (zh_TW)
 
 ### Data Flow (local-first with cloud sync)
@@ -33,7 +36,19 @@ firebase deploy --only firestore:rules                       # Deploy Firestore 
 UI (ConsumerWidget) → ref.watch(provider) → StreamProvider → Isar .watch()
 UI mutation → AsyncNotifier → Isar writeTxn() → ActivityLogger → FirebaseSyncService (fire-and-forget)
 Firestore listener → mergeFromRemote() → Isar writeTxn() (newer timestamp wins)
+Receipt photos → ReceiptStorageService → Firebase Storage (URL replaces local path)
 ```
+
+### Auth Flow
+```
+App launch → _AuthGate checks AuthService.isSignedIn
+  ├── Not signed in → LoginPage (Google Sign-In required)
+  └── Signed in → MainShell (all features accessible)
+      → FirebaseSyncService.initialSync() → Firestore realtime listeners
+```
+- Google Sign-In is mandatory — no anonymous mode, no data visible before login
+- Same Google account across devices = same Firebase UID = auto-sync
+- Invite code feature hidden in UI (code preserved for future use)
 
 ### Provider Pattern
 - **StreamProvider**: Real-time Isar queries with `.watch(fireImmediately: true)` — lists (members, expenses, categories, notifications)
@@ -56,22 +71,24 @@ Firestore listener → mergeFromRemote() → Isar writeTxn() (newer timestamp wi
 | ActivityLog | Operation audit trail (action, actor, timestamp) |
 | AppNotification | In-app notifications for split expense participants |
 
-### Firebase Sync Architecture
+### Firebase Architecture
 ```
+Auth: Google Sign-In (mandatory) → Firebase UID shared across devices
 Firestore: groups/{groupId}/[members|expenses|settlements]/{id}
-Security: memberUids[] array on group doc — only listed UIDs can read/write
-Auth: Apple Sign-In (primary) → same Apple ID = same UID across devices
-      Anonymous (fallback) → single device only
+Storage: receipts/{groupId}/{expenseId}/{uuid}.jpg
+Security: memberUids[] on group doc — only listed UIDs can read/write
 Conflict: updatedAt/createdAt timestamp comparison, newer wins
 ```
-- `FirebaseSyncService.initialSync()` — uploads all local data on startup
+- `FirebaseSyncService.initialSync()` — uploads all local data after Google login
 - `startRealtimeSync()` — Firestore snapshot listeners for expenses + settlements
+- `ReceiptStorageService` — uploads receipt photos to Firebase Storage, replaces local paths with URLs
 - Sync is fire-and-forget: local write always succeeds, remote sync fails silently
+- Schema incompatibility auto-recovery: Isar DB is rebuilt if schema version mismatch
 
 ### Voice Input Pipeline
 ```
 speech_to_text (on-device, zh_TW) → raw text
-  ├── Gemini API (if API key set) → structured JSON
+  ├── Gemini API (if API key set) → structured JSON (x-goog-api-key header)
   └── LocalExpenseParser (fallback) → regex + Chinese numeral conversion
       → {description, amount, category, date} → auto-fill form
 ```
@@ -81,7 +98,7 @@ LocalExpenseParser handles: Chinese numerals (三百五→350, 兩萬五→25000
 Three split methods (equal/percentage/custom), net debt calculation with settlement deduction, and greedy debt simplification (minimum cash flow algorithm). Amounts are rounded to integers (NT$). Percentage split assigns remainder to last person.
 
 ### Navigation
-`MainShell` in `app.dart` uses `IndexedStack` + `NavigationBar` (5 tabs: 首頁/拆帳/記錄/統計/設定). The FAB pushes `ExpenseFormPage` modally. `ExpenseFormPage` accepts optional `existingExpense` (edit) or `duplicateFrom` (copy).
+`_AuthGate` in `app.dart` gates all access behind Google login. `MainShell` uses `IndexedStack` + `NavigationBar` (5 tabs: 首頁/拆帳/記錄/統計/設定). The FAB pushes `ExpenseFormPage` modally. `ExpenseFormPage` accepts optional `existingExpense` (edit) or `duplicateFrom` (copy).
 
 ## Conventions
 
@@ -95,12 +112,26 @@ Three split methods (equal/percentage/custom), net debt calculation with settlem
 - **Logging**: All CRUD operations must call `ActivityLogger.log()` after Isar write
 - **Firebase sync**: All CRUD providers call `FirebaseSyncService.sync*Up()` after Isar write, wrapped in `.catchError((_) {})`
 - **Photos**: Up to 10 receipt photos per expense (`receiptPaths` list), backward compatible with old `receiptPath` field
+- **API Key storage**: Sensitive keys (Gemini) stored via `flutter_secure_storage` (Keychain), never in plain JSON
+- **API Key transmission**: Use HTTP headers (`x-goog-api-key`), never URL query parameters
+
+## Security
+
+- **Firebase App Check**: Enabled with `AppleProvider.debug` in kDebugMode, `deviceCheck` in release
+- **Firestore Rules**: `firestore.rules` — member-only access, owner-only delete, field validation, default-deny
+- **Storage Rules**: `storage.rules` — auth required, 10MB limit, image types only
+- **Invite code**: 8-char cryptographic random (Random.secure()), 24h expiry, max 5 uses
+- **Deserialization**: Defensive null checks + try-catch on all Firestore → Isar merges
+- **macOS sandbox**: Disabled (`com.apple.security.app-sandbox: false`) for Keychain access compatibility
 
 ## Known Constraints
 
 - **Isar + Web**: Isar's generated code uses large integer literals that exceed JS precision — web builds fail. Target mobile/desktop only.
 - **Isar experimental warnings**: `.g.dart` files produce ~48 `experimental_member_use` warnings — expected, cannot be suppressed.
 - **`.g.dart` in gitignore**: Generated files are not committed. Always run `build_runner` after cloning.
-- **Apple Sign-In setup**: Requires Xcode capability "Sign In with Apple" on both iOS and macOS targets, plus Firebase Console Authentication → Apple enabled.
+- **Google Sign-In on macOS**: Requires `CFBundleURLSchemes` with REVERSED_CLIENT_ID in `macos/Runner/Info.plist`.
+- **macOS code signing**: `flutter build macos` does not properly sign for Keychain. Use Xcode build instead.
 - **Firestore rules**: Production rules in `firestore.rules`, deploy with `firebase deploy --only firestore:rules`.
+- **Storage rules**: Production rules in `storage.rules`, deploy with `firebase deploy --only storage`.
 - **share_plus v12**: Upgraded from v9 due to Firebase dependency conflict. Uses `SharePlus.instance.share(ShareParams(...))` API.
+- **Apple Sign-In**: Code exists in `AuthService` but UI hidden (requires paid Apple Developer Program $99/yr).

--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -2,7 +2,6 @@
 
 ## 前置條件
 - 安裝 Firebase CLI：`npm install -g firebase-tools`
-- 安裝 FlutterFire CLI：`dart pub global activate flutterfire_cli`
 - 有 Google 帳號
 
 ## 步驟
@@ -19,66 +18,57 @@
 1. 在 Firebase Console 左側選單 → **Firestore Database**
 2. 點「建立資料庫」
 3. 選擇地區：`asia-east1`（台灣）或 `asia-northeast1`（東京）
-4. 選「正式模式」（之後設定 Security Rules）
+4. 選「正式模式」
 
 ### 3. 啟用 Authentication
 
 1. 左側選單 → **Authentication** → **開始使用**
-2. 在「登入方式」分頁 → 啟用「匿名」登入
-3. （未來可加入 Google Sign-In、Apple Sign-In）
+2. 在「登入方式」分頁 → 啟用 **Google**（必要）
+3. 填入支援電子郵件 → 儲存
 
-### 4. 設定 FlutterFire
+### 4. 啟用 Storage
 
-在專案根目錄執行：
+1. 左側選單 → **Storage** → **Get Started**
+2. 選擇地區：`asia-east1`
 
-```bash
-# 登入 Firebase
-firebase login
+### 5. 下載 GoogleService-Info.plist
 
-# 自動設定 Flutter 專案（會產生 firebase_options.dart）
-flutterfire configure --project=你的專案ID
-```
+1. Firebase Console → ⚙️ **專案設定** → 你的 iOS app
+2. 下載 `GoogleService-Info.plist`
+3. 複製到 `ios/Runner/GoogleService-Info.plist` 和 `macos/Runner/GoogleService-Info.plist`
+4. 確認 plist 內有 `CLIENT_ID` 和 `REVERSED_CLIENT_ID`（啟用 Google 登入後才會有）
 
-選擇平台時勾選：
-- ✅ iOS
-- ✅ macOS
-- ✅ Android（如果需要）
+### 6. 更新 firebase_options.dart
 
-### 5. iOS 額外設定
+從 plist 取出以下值更新 `lib/firebase_options.dart`：
+- `apiKey` (API_KEY)
+- `appId` (GOOGLE_APP_ID)
+- `messagingSenderId` (GCM_SENDER_ID)
+- `projectId` (PROJECT_ID)
+- `storageBucket` (STORAGE_BUCKET)
+- `iosClientId` (CLIENT_ID)
 
-`flutterfire configure` 會自動處理大部分設定。確認：
+### 7. 更新 Info.plist URL Scheme
 
-- `ios/Runner/GoogleService-Info.plist` 已產生
-- `macos/Runner/GoogleService-Info.plist` 已產生
+在 `ios/Runner/Info.plist` 和 `macos/Runner/Info.plist` 的 `CFBundleURLSchemes` 中填入 plist 的 `REVERSED_CLIENT_ID` 值。
 
-### 6. 設定 Firestore Security Rules
+### 8. 部署 Security Rules
 
-在 Firebase Console → Firestore → 規則，貼上 `firestore.rules` 檔案的內容。
-
-或使用 Firebase CLI 部署：
 ```bash
 firebase deploy --only firestore:rules
+firebase deploy --only storage
 ```
 
 正式環境規則包含：
 - **群組成員驗證**：只有 `memberUids[]` 內的 UID 可讀寫
 - **擁有者特權**：僅 `ownerUid` 可刪除群組或轉移擁有權
 - **欄位型別驗證**：金額必須為正數且 < 1 億，描述 ≤ 200 字
-- **文件大小限制**：每筆文件最多 30 個欄位
 - **預設拒絕**：未定義的路徑全部拒絕存取
-
-### 7. 啟用同步
-
-`flutterfire configure` 完成後，在 `lib/main.dart` 取消以下註解：
-
-```dart
-import 'package:firebase_core/firebase_core.dart';
-import 'firebase_options.dart';
-
-// 在 main() 中：
-await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-```
+- **Storage**：需登入、檔案 < 10MB、僅圖片類型
 
 ### 驗證
 
-執行 `flutter run`，如果沒有錯誤，Firebase 已成功連接。
+1. 用 Xcode 開啟 `ios/Runner.xcworkspace` 或 `macos/Runner.xcworkspace`
+2. 按 ▶ Run
+3. 應顯示 Google 登入頁面
+4. 登入後資料自動同步到 Firestore


### PR DESCRIPTION
## Documentation Update

| File | Changes |
|------|---------|
| `CLAUDE.md` | Auth flow (Google mandatory), Storage, Security section, macOS build note, constraints |
| `docs/firebase-setup.md` | Google auth, Storage setup, manual config steps, verification |

🤖 Generated with [Claude Code](https://claude.com/claude-code)