### PR TITLE
fix(auth): wait for Firebase auth session restore on app restart

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -64,11 +64,34 @@ class _AuthGate extends StatefulWidget {
 }
 
 class _AuthGateState extends State<_AuthGate> {
-  bool _isLoggedIn = AuthService.isSignedIn;
+  bool? _isLoggedIn; // null = 載入中
+
+  @override
+  void initState() {
+    super.initState();
+    // 監聽 Firebase Auth 狀態（處理 app 重啟時的 session 恢復）
+    AuthService.authStateChanges.first.then((user) {
+      if (mounted) {
+        setState(() => _isLoggedIn = user != null && !user.isAnonymous);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (!_isLoggedIn) {
+    // 載入中：顯示 splash
+    if (_isLoggedIn == null) {
+      return Scaffold(
+        body: Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
+          Icon(Icons.account_balance_wallet, size: 64,
+              color: Theme.of(context).colorScheme.primary),
+          const SizedBox(height: 16),
+          const CircularProgressIndicator(),
+        ])),
+      );
+    }
+
+    if (!_isLoggedIn!) {
       return LoginPage(
         onLoginSuccess: () => setState(() => _isLoggedIn = true),
       );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,9 +34,10 @@ void main() async {
     // App Check 啟用失敗不阻擋 app 啟動
   }
 
-  // 已登入 Google → 自動同步
+  // 等待 Firebase Auth 恢復 session，然後同步
   try {
-    if (AuthService.isSignedIn) {
+    final user = await AuthService.authStateChanges.first;
+    if (user != null && !user.isAnonymous) {
       await FirebaseSyncService.initialSync();
     }
   } catch (_) {


### PR DESCRIPTION
Fixes iOS crash on relaunch after Google login. AuthGate now listens to authStateChanges stream instead of synchronous read. Shows loading spinner while session restores.