### PR TITLE
feat: add structured logging service with in-app debug log viewer

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'services/database_service.dart';
 import 'services/local_notification_service.dart';
 import 'services/firebase_sync_service.dart';
 import 'services/auth_service.dart';
+import 'services/log_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
@@ -13,15 +14,19 @@ import 'app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  LogService.info(LogTag.APP, 'App starting...');
 
   // 初始化繁體中文日期格式
   await initializeDateFormatting('zh_TW', null);
 
   // 初始化 Isar 資料庫
+  LogService.info(LogTag.DB, 'Initializing Isar database');
   await DatabaseService.instance;
 
   // 初始化 Firebase
+  LogService.info(LogTag.APP, 'Initializing Firebase');
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  LogService.info(LogTag.APP, 'Firebase initialized');
 
   // 啟用 App Check 防止 API 濫用
   // Debug/本機 build 使用 debug provider，App Store release 才用 deviceCheck
@@ -30,22 +35,28 @@ void main() async {
       appleProvider: kDebugMode ? AppleProvider.debug : AppleProvider.deviceCheck,
       androidProvider: kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
     );
-  } catch (_) {
-    // App Check 啟用失敗不阻擋 app 啟動
+    LogService.info(LogTag.APP, 'App Check activated (${kDebugMode ? "debug" : "release"} mode)');
+  } catch (e, st) {
+    LogService.error(LogTag.APP, 'App Check activation failed', e, st);
   }
 
   // 等待 Firebase Auth 恢復 session，然後同步
   try {
+    LogService.info(LogTag.AUTH, 'Waiting for auth session restore');
     final user = await AuthService.authStateChanges.first;
     if (user != null && !user.isAnonymous) {
+      LogService.info(LogTag.AUTH, 'Session restored: ${user.email ?? user.uid}');
       await FirebaseSyncService.initialSync();
+    } else {
+      LogService.info(LogTag.AUTH, 'No active session');
     }
-  } catch (_) {
-    // 同步失敗不阻擋 app 啟動
+  } catch (e, st) {
+    LogService.error(LogTag.SYNC, 'Initial sync failed', e, st);
   }
 
   // 初始化本地推播通知
   await LocalNotificationService.init();
+  LogService.info(LogTag.APP, 'App startup complete');
 
   runApp(
     const ProviderScope(

--- a/lib/screens/settings/debug_log_page.dart
+++ b/lib/screens/settings/debug_log_page.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import '../../services/log_service.dart';
+
+class DebugLogPage extends StatefulWidget {
+  const DebugLogPage({super.key});
+
+  @override
+  State<DebugLogPage> createState() => _DebugLogPageState();
+}
+
+class _DebugLogPageState extends State<DebugLogPage> {
+  LogTag? _filterTag;
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Debug Log'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.copy),
+            tooltip: '複製全部',
+            onPressed: () {
+              final text = LogService.instance.exportAll();
+              Clipboard.setData(ClipboardData(text: text));
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('已複製到剪貼簿')),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: '清除',
+            onPressed: () {
+              LogService.instance.clear();
+              setState(() {});
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // Tag filter chips
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              children: [
+                _buildFilterChip(theme, null, '全部'),
+                for (final tag in LogTag.values)
+                  _buildFilterChip(theme, tag, tag.name),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          // Log list
+          Expanded(
+            child: StreamBuilder<List<LogEntry>>(
+              stream: LogService.instance.stream,
+              initialData: LogService.instance.entries,
+              builder: (context, snapshot) {
+                final allEntries = snapshot.data ?? [];
+                final entries = _filterTag == null
+                    ? allEntries
+                    : allEntries.where((e) => e.tag == _filterTag).toList();
+
+                if (entries.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.terminal, size: 64,
+                            color: theme.colorScheme.primary.withValues(alpha: 0.3)),
+                        const SizedBox(height: 16),
+                        Text('尚無 Log 記錄', style: theme.textTheme.titleMedium),
+                      ],
+                    ),
+                  );
+                }
+
+                return ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(8),
+                  reverse: true,
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final entry = entries[entries.length - 1 - index];
+                    return _buildLogTile(theme, entry);
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterChip(ThemeData theme, LogTag? tag, String label) {
+    final selected = _filterTag == tag;
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: FilterChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: (_) => setState(() => _filterTag = tag),
+      ),
+    );
+  }
+
+  Widget _buildLogTile(ThemeData theme, LogEntry entry) {
+    final (icon, color) = switch (entry.level) {
+      LogLevel.error => (Icons.error_outline, theme.colorScheme.error),
+      LogLevel.warning => (Icons.warning_amber, Colors.orange),
+      LogLevel.info => (Icons.info_outline, theme.colorScheme.primary),
+      LogLevel.debug => (Icons.bug_report_outlined, Colors.grey),
+    };
+
+    final time = DateFormat('HH:mm:ss').format(entry.timestamp);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(time,
+              style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  fontFamily: 'monospace',
+                  fontSize: 11)),
+          const SizedBox(width: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(entry.tag.name,
+                style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: color)),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(entry.message,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                        fontFamily: 'monospace', fontSize: 12)),
+                if (entry.error != null)
+                  Text(entry.error!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                          fontSize: 11,
+                          color: theme.colorScheme.error)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -10,8 +10,10 @@ import '../auth/login_page.dart';
 import '../../app.dart';
 import '../../services/database_service.dart';
 import '../../providers/theme_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'category_management_page.dart';
 import 'activity_log_page.dart';
+import 'debug_log_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -180,6 +182,17 @@ class SettingsPage extends ConsumerWidget {
               onTap: () => Navigator.push(context,
                   MaterialPageRoute(builder: (_) => const ActivityLogPage())),
             ),
+            if (kDebugMode) ...[
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.terminal),
+                title: const Text('Debug Log'),
+                subtitle: const Text('技術除錯記錄'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => Navigator.push(context,
+                    MaterialPageRoute(builder: (_) => const DebugLogPage())),
+              ),
+            ],
           ])),
           const Gap(16),
           // 帳號

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,6 +4,7 @@ import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'log_service.dart';
 
 /// 認證服務（Google Sign-In / Apple Sign-In + Firebase Auth）
 class AuthService {
@@ -26,6 +27,7 @@ class AuthService {
 
   /// Apple Sign-In
   static Future<User?> signInWithApple() async {
+    LogService.info(LogTag.AUTH, 'Apple Sign-In started');
     // 產生 nonce 防止 replay attack
     final rawNonce = _generateNonce();
     final nonce = _sha256ofString(rawNonce);
@@ -49,12 +51,15 @@ class AuthService {
     UserCredential result;
     if (currentUser != null && currentUser!.isAnonymous) {
       try {
+        LogService.debug(LogTag.AUTH, 'Linking anonymous account to Apple');
         result = await currentUser!.linkWithCredential(oauthCredential);
       } on FirebaseAuthException catch (e) {
         if (e.code == 'credential-already-in-use') {
+          LogService.warning(LogTag.AUTH, 'Apple credential already in use, signing in directly');
           // 這個 Apple ID 已在別的裝置登入過 → 直接登入那個帳號
           result = await _auth.signInWithCredential(oauthCredential);
         } else {
+          LogService.error(LogTag.AUTH, 'Apple Sign-In link failed', e);
           rethrow;
         }
       }
@@ -74,19 +79,25 @@ class AuthService {
       }
     }
 
+    LogService.info(LogTag.AUTH, 'Apple Sign-In success: ${user?.email ?? user?.uid}');
     return user;
   }
 
   /// Google Sign-In（含 serverClientId 給 iOS/macOS 使用）
   static Future<User?> signInWithGoogle() async {
+    LogService.info(LogTag.AUTH, 'Google Sign-In started');
     final googleSignIn = GoogleSignIn(
       scopes: ['email'],
       serverClientId: '137558877215-85ak3t2lbne5iuad4aoop4fadn2m4p7u.apps.googleusercontent.com',
     );
 
     final googleUser = await googleSignIn.signIn();
-    if (googleUser == null) return null; // 使用者取消
+    if (googleUser == null) {
+      LogService.info(LogTag.AUTH, 'Google Sign-In cancelled by user');
+      return null;
+    }
 
+    LogService.debug(LogTag.AUTH, 'Google auth: ${googleUser.email}');
     final googleAuth = await googleUser.authentication;
     final credential = GoogleAuthProvider.credential(
       accessToken: googleAuth.accessToken,
@@ -97,11 +108,14 @@ class AuthService {
     UserCredential result;
     if (currentUser != null && currentUser!.isAnonymous) {
       try {
+        LogService.debug(LogTag.AUTH, 'Linking anonymous account to Google');
         result = await currentUser!.linkWithCredential(credential);
       } on FirebaseAuthException catch (e) {
         if (e.code == 'credential-already-in-use') {
+          LogService.warning(LogTag.AUTH, 'Google credential already in use, signing in directly');
           result = await _auth.signInWithCredential(credential);
         } else {
+          LogService.error(LogTag.AUTH, 'Google Sign-In link failed', e);
           rethrow;
         }
       }
@@ -109,6 +123,7 @@ class AuthService {
       result = await _auth.signInWithCredential(credential);
     }
 
+    LogService.info(LogTag.AUTH, 'Google Sign-In success: ${result.user?.email ?? result.user?.uid}');
     return result.user;
   }
 
@@ -120,7 +135,9 @@ class AuthService {
 
   /// 登出
   static Future<void> signOut() async {
+    LogService.info(LogTag.AUTH, 'Signing out: ${currentUser?.email ?? currentUser?.uid}');
     await _auth.signOut();
+    LogService.info(LogTag.AUTH, 'Signed out');
   }
 
   /// 監聽登入狀態變更

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -11,6 +11,7 @@ import '../models/activity_log.dart';
 import '../models/app_notification.dart';
 import '../models/enums.dart';
 import 'package:uuid/uuid.dart';
+import 'log_service.dart';
 
 /// Isar 資料庫管理服務
 class DatabaseService {
@@ -44,8 +45,10 @@ class DatabaseService {
         directory: dir.path,
         name: 'family_ledger',
       );
+      LogService.info(LogTag.DB, 'Isar opened at ${dir.path}');
     } catch (e) {
       // Schema 不相容 → 刪除舊 DB 重建（開發階段可接受）
+      LogService.warning(LogTag.DB, 'Isar schema mismatch, rebuilding DB', e);
       await Isar.getInstance('family_ledger')?.close();
       final dbFile = File('${dir.path}/family_ledger.isar');
       if (await dbFile.exists()) await dbFile.delete();
@@ -56,6 +59,7 @@ class DatabaseService {
         directory: dir.path,
         name: 'family_ledger',
       );
+      LogService.info(LogTag.DB, 'Isar rebuilt successfully');
     }
 
     // 首次啟動：建立預設群組和類別
@@ -70,7 +74,11 @@ class DatabaseService {
 
     // 檢查是否已有群組
     final groupCount = await isar.familyGroups.count();
-    if (groupCount > 0) return;
+    if (groupCount > 0) {
+      LogService.debug(LogTag.DB, 'Existing data found ($groupCount groups)');
+      return;
+    }
+    LogService.info(LogTag.DB, 'First launch, seeding default data');
 
     final groupId = _uuid.v4();
     final now = DateTime.now();

--- a/lib/services/firebase_sync_service.dart
+++ b/lib/services/firebase_sync_service.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'auth_service.dart';
+import 'log_service.dart';
 import 'package:isar/isar.dart';
 import '../models/expense.dart';
 import '../models/family_member.dart';
@@ -46,9 +47,13 @@ class FirebaseSyncService {
   /// 首次同步：把本地群組、成員、支出、結算上傳到 Firestore
   static Future<void> initialSync() async {
     if (!isSignedIn) return;
+    LogService.info(LogTag.SYNC, 'Initial sync started');
     final isar = await DatabaseService.instance;
     final groupId = await DatabaseService.getPrimaryGroupId();
-    if (groupId == null) return;
+    if (groupId == null) {
+      LogService.warning(LogTag.SYNC, 'No primary group found, skipping sync');
+      return;
+    }
 
     // 上傳群組
     final group = await isar.familyGroups.filter().idEqualTo(groupId).findFirst();
@@ -72,15 +77,18 @@ class FirebaseSyncService {
       await syncSettlementUp(groupId, s);
     }
 
+    LogService.info(LogTag.SYNC, 'Initial sync uploaded: ${members.length} members, ${expenses.length} expenses, ${settlements.length} settlements');
+
     // 開始即時監聽
     startRealtimeSync(groupId);
   }
 
   /// 開始即時監聽 Firestore 變更（支出 + 結算）
   static void startRealtimeSync(String groupId) {
-    if (_syncedGroupId == groupId) return; // 已在監聽
+    if (_syncedGroupId == groupId) return; // 已在監聯
     stopRealtimeSync();
     _syncedGroupId = groupId;
+    LogService.info(LogTag.SYNC, 'Realtime sync started for group $groupId');
 
     // 監聽遠端支出變更
     _expenseListener = _expensesRef(groupId)
@@ -95,6 +103,7 @@ class FirebaseSyncService {
             await isar.writeTxn(() async {
               await isar.expenses.delete(local.isarId);
             });
+            LogService.debug(LogTag.SYNC, 'Remote expense deleted: ${change.doc.id}');
           }
         } else {
           // 新增或修改 → merge 到本地
@@ -104,6 +113,8 @@ class FirebaseSyncService {
           }
         }
       }
+    }, onError: (e) {
+      LogService.error(LogTag.SYNC, 'Expense listener error', e);
     });
 
     // 監聽遠端結算變更
@@ -118,6 +129,7 @@ class FirebaseSyncService {
             await isar.writeTxn(() async {
               await isar.settlements.delete(local.isarId);
             });
+            LogService.debug(LogTag.SYNC, 'Remote settlement deleted: ${change.doc.id}');
           }
         } else {
           final data = change.doc.data();
@@ -126,6 +138,8 @@ class FirebaseSyncService {
           }
         }
       }
+    }, onError: (e) {
+      LogService.error(LogTag.SYNC, 'Settlement listener error', e);
     });
   }
 
@@ -136,17 +150,22 @@ class FirebaseSyncService {
     _expenseListener = null;
     _settlementListener = null;
     _syncedGroupId = null;
+    LogService.debug(LogTag.SYNC, 'Realtime sync stopped');
   }
 
   /// 將遠端結算寫入本地 Isar
   static Future<void> _mergeSettlementFromRemote(
       Map<String, dynamic> data, String settlementId) async {
+    try {
     final isar = await DatabaseService.instance;
     final local = await isar.settlements.filter().idEqualTo(settlementId).findFirst();
     final remoteCreatedAt = (data['createdAt'] as Timestamp).toDate();
 
     // 如果本地已有且較新，跳過
-    if (local != null && local.createdAt.isAfter(remoteCreatedAt)) return;
+    if (local != null && local.createdAt.isAfter(remoteCreatedAt)) {
+      LogService.debug(LogTag.SYNC, 'Settlement $settlementId: local is newer, skipping');
+      return;
+    }
 
     final settlement = Settlement()
       ..id = settlementId
@@ -165,6 +184,10 @@ class FirebaseSyncService {
     await isar.writeTxn(() async {
       await isar.settlements.put(settlement);
     });
+    LogService.debug(LogTag.SYNC, 'Settlement merged: $settlementId');
+    } catch (e, st) {
+      LogService.error(LogTag.SYNC, 'Failed to merge settlement $settlementId', e, st);
+    }
   }
 
   // ── 群組同步 ──
@@ -339,8 +362,9 @@ class FirebaseSyncService {
       await isar.writeTxn(() async {
         await isar.expenses.put(expense);
       });
-    } catch (_) {
-      // 防禦性：任何反序列化錯誤靜默忽略，不影響 app 運行
+      LogService.debug(LogTag.SYNC, 'Expense merged: $expenseId ($description)');
+    } catch (e, st) {
+      LogService.error(LogTag.SYNC, 'Failed to merge expense $expenseId', e, st);
     }
   }
 

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+
+enum LogLevel { debug, info, warning, error }
+
+enum LogTag { APP, AUTH, SYNC, DB, STORAGE }
+
+class LogEntry {
+  final DateTime timestamp;
+  final LogLevel level;
+  final LogTag tag;
+  final String message;
+  final String? error;
+  final String? stackTrace;
+
+  LogEntry({
+    required this.timestamp,
+    required this.level,
+    required this.tag,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  String get formatted {
+    final time = DateFormat('HH:mm:ss').format(timestamp);
+    final lvl = level.name.toUpperCase();
+    final base = '[$time] [$lvl] [${tag.name}] $message';
+    if (error != null) return '$base\n  Error: $error';
+    return base;
+  }
+}
+
+class LogService {
+  LogService._();
+  static final LogService _instance = LogService._();
+  static LogService get instance => _instance;
+
+  static const int _maxEntries = 500;
+  final List<LogEntry> _entries = [];
+  final _controller = StreamController<List<LogEntry>>.broadcast();
+
+  Stream<List<LogEntry>> get stream => _controller.stream;
+  List<LogEntry> get entries => List.unmodifiable(_entries);
+
+  void _add(LogLevel level, LogTag tag, String message,
+      [Object? error, StackTrace? stackTrace]) {
+    final entry = LogEntry(
+      timestamp: DateTime.now(),
+      level: level,
+      tag: tag,
+      message: message,
+      error: error?.toString(),
+      stackTrace: stackTrace?.toString(),
+    );
+
+    _entries.add(entry);
+    if (_entries.length > _maxEntries) {
+      _entries.removeAt(0);
+    }
+
+    // Console output
+    final line = entry.formatted;
+    if (level == LogLevel.error || level == LogLevel.warning) {
+      developer.log(line, name: tag.name, level: level == LogLevel.error ? 1000 : 900);
+    } else if (kDebugMode) {
+      debugPrint(line);
+    }
+
+    _controller.add(List.unmodifiable(_entries));
+  }
+
+  static void debug(LogTag tag, String message) =>
+      _instance._add(LogLevel.debug, tag, message);
+
+  static void info(LogTag tag, String message) =>
+      _instance._add(LogLevel.info, tag, message);
+
+  static void warning(LogTag tag, String message, [Object? error]) =>
+      _instance._add(LogLevel.warning, tag, message, error);
+
+  static void error(LogTag tag, String message,
+      [Object? error, StackTrace? stackTrace]) =>
+      _instance._add(LogLevel.error, tag, message, error, stackTrace);
+
+  void clear() {
+    _entries.clear();
+    _controller.add(List.unmodifiable(_entries));
+  }
+
+  String exportAll() {
+    return _entries.map((e) => e.formatted).join('\n');
+  }
+}

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -12,3 +12,7 @@ PRODUCT_BUNDLE_IDENTIFIER = com.familyledger.familyLedger
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.familyledger. All rights reserved.
+
+// Development team and signing identity (required for Keychain access)
+DEVELOPMENT_TEAM = 63VUXLNBVU
+CODE_SIGN_IDENTITY = Apple Development

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -39,5 +39,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>FLTEnableMergedPlatformUIThread</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `LogService` singleton with leveled logging (debug/info/warning/error) and tagged categories (AUTH/SYNC/DB/APP/STORAGE)
- Add in-app Debug Log viewer page accessible from Settings (debug mode only), with tag filtering and one-tap copy
- Replace all silent `catch (_) {}` blocks in auth_service, firebase_sync_service, database_service, and main.dart with structured log calls
- Fix macOS code signing (`CODE_SIGN_IDENTITY = Apple Development`) to resolve Keychain access error after Google Sign-In

## Files Changed
- **New**: `lib/services/log_service.dart` — core logging service (circular buffer, console + stream output)
- **New**: `lib/screens/settings/debug_log_page.dart` — debug log viewer UI
- **Modified**: `lib/main.dart` — structured log for each startup step
- **Modified**: `lib/services/auth_service.dart` — Google/Apple Sign-In logging
- **Modified**: `lib/services/firebase_sync_service.dart` — sync operation logging
- **Modified**: `lib/services/database_service.dart` — Isar init logging
- **Modified**: `lib/screens/settings/settings_page.dart` — Debug Log entry point
- **Modified**: `macos/Runner/Configs/AppInfo.xcconfig` — CODE_SIGN_IDENTITY fix

## Test plan
- [ ] `flutter analyze` passes (no new errors)
- [ ] Xcode build succeeds
- [ ] App startup → console shows structured log output for each init step
- [ ] Google Sign-In → console shows AUTH log entries
- [ ] Settings → Debug Log → displays all log entries with tag filtering
- [ ] Copy button copies all logs to clipboard
- [ ] Disconnect network → trigger sync error → error appears in both console and Debug Log viewer

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)