### PR TITLE
fix(auth): add login page debug diagnostics for Google Sign-In failure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'services/database_service.dart';
@@ -27,6 +29,17 @@ void main() async {
   LogService.info(LogTag.APP, 'Initializing Firebase');
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   LogService.info(LogTag.APP, 'Firebase initialized');
+
+  // macOS: 設定 Firebase Auth 使用 app 本地 keychain（避免 keychain-error）
+  if (Platform.isMacOS) {
+    try {
+      const channel = MethodChannel('com.familyledger/auth_config');
+      await channel.invokeMethod('configureKeychainAccess');
+      LogService.info(LogTag.AUTH, 'macOS keychain access configured');
+    } catch (e) {
+      LogService.warning(LogTag.AUTH, 'macOS keychain config failed (non-fatal)', e);
+    }
+  }
 
   // 啟用 App Check 防止 API 濫用
   // Debug/本機 build 使用 debug provider，App Store release 才用 deviceCheck

--- a/lib/screens/auth/login_page.dart
+++ b/lib/screens/auth/login_page.dart
@@ -1,7 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:gap/gap.dart';
 import '../../services/auth_service.dart';
 import '../../services/firebase_sync_service.dart';
+import '../../services/log_service.dart';
+import '../settings/debug_log_page.dart';
 
 /// 登入頁面（未登入 Google 前不能使用 app）
 class LoginPage extends StatefulWidget {
@@ -18,6 +22,7 @@ class _LoginPageState extends State<LoginPage> {
 
   Future<void> _signIn() async {
     setState(() { _isLoading = true; _error = null; });
+    LogService.info(LogTag.AUTH, 'Login button pressed');
     try {
       final user = await AuthService.signInWithGoogle();
       if (user == null) {
@@ -25,10 +30,15 @@ class _LoginPageState extends State<LoginPage> {
         return; // 使用者取消
       }
       // 登入成功，同步資料
+      LogService.info(LogTag.AUTH, 'Login success, starting initial sync');
       await FirebaseSyncService.initialSync();
       widget.onLoginSuccess();
-    } catch (e) {
-      setState(() { _isLoading = false; _error = '$e'; });
+    } catch (e, st) {
+      LogService.error(LogTag.AUTH, 'Login failed (${e.runtimeType})', e, st);
+      setState(() {
+        _isLoading = false;
+        _error = '${e.runtimeType}: $e';
+      });
     }
   }
 
@@ -72,14 +82,59 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               if (_error != null) ...[
                 const Gap(16),
-                Text(_error!, style: TextStyle(color: theme.colorScheme.error, fontSize: 13),
-                    textAlign: TextAlign.center),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.errorContainer,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('登入失敗', style: TextStyle(
+                        color: theme.colorScheme.onErrorContainer,
+                        fontWeight: FontWeight.bold, fontSize: 13)),
+                      const Gap(4),
+                      SelectableText(_error!, style: TextStyle(
+                        color: theme.colorScheme.onErrorContainer, fontSize: 12)),
+                      const Gap(8),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.copy, size: 14),
+                          label: const Text('複製錯誤', style: TextStyle(fontSize: 12)),
+                          onPressed: () {
+                            Clipboard.setData(ClipboardData(text: _error!));
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('已複製'), duration: Duration(seconds: 1)),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ],
               const Gap(24),
               Text('登入後可在多台裝置間同步資料',
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurface.withValues(alpha: 0.4)),
                   textAlign: TextAlign.center),
+              // Debug Log 入口（僅 debug mode）
+              if (kDebugMode) ...[
+                const Gap(32),
+                TextButton.icon(
+                  icon: Icon(Icons.bug_report_outlined, size: 16,
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.4)),
+                  label: Text('Debug Log', style: TextStyle(
+                    fontSize: 12,
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.4))),
+                  onPressed: () {
+                    Navigator.push(context,
+                      MaterialPageRoute(builder: (_) => const DebugLogPage()));
+                  },
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -91,39 +91,65 @@ class AuthService {
       serverClientId: '137558877215-85ak3t2lbne5iuad4aoop4fadn2m4p7u.apps.googleusercontent.com',
     );
 
-    final googleUser = await googleSignIn.signIn();
+    // Step 1: 開啟 Google 登入畫面
+    LogService.debug(LogTag.AUTH, 'Step 1: Opening Google Sign-In popup');
+    final GoogleSignInAccount? googleUser;
+    try {
+      googleUser = await googleSignIn.signIn();
+    } catch (e, st) {
+      LogService.error(LogTag.AUTH, 'Step 1 FAILED: Google Sign-In popup error (${e.runtimeType})', e, st);
+      rethrow;
+    }
     if (googleUser == null) {
-      LogService.info(LogTag.AUTH, 'Google Sign-In cancelled by user');
+      LogService.info(LogTag.AUTH, 'Step 1: Google Sign-In cancelled by user');
       return null;
     }
+    LogService.info(LogTag.AUTH, 'Step 1 OK: Google user = ${googleUser.email}');
 
-    LogService.debug(LogTag.AUTH, 'Google auth: ${googleUser.email}');
-    final googleAuth = await googleUser.authentication;
+    // Step 2: 取得 Google 認證 token
+    LogService.debug(LogTag.AUTH, 'Step 2: Getting Google auth tokens');
+    final GoogleSignInAuthentication googleAuth;
+    try {
+      googleAuth = await googleUser.authentication;
+    } catch (e, st) {
+      LogService.error(LogTag.AUTH, 'Step 2 FAILED: Google auth token error (${e.runtimeType})', e, st);
+      rethrow;
+    }
+    LogService.info(LogTag.AUTH, 'Step 2 OK: accessToken=${googleAuth.accessToken != null ? "present" : "NULL"}, idToken=${googleAuth.idToken != null ? "present" : "NULL"}');
+
+    // Step 3: 建立 Firebase credential
     final credential = GoogleAuthProvider.credential(
       accessToken: googleAuth.accessToken,
       idToken: googleAuth.idToken,
     );
+    LogService.debug(LogTag.AUTH, 'Step 3: Firebase credential created');
 
-    // 如果目前是匿名登入，先嘗試 link（保留原有資料）
+    // Step 4: Firebase signInWithCredential
+    LogService.debug(LogTag.AUTH, 'Step 4: Calling Firebase signInWithCredential');
     UserCredential result;
     if (currentUser != null && currentUser!.isAnonymous) {
       try {
-        LogService.debug(LogTag.AUTH, 'Linking anonymous account to Google');
+        LogService.debug(LogTag.AUTH, 'Step 4: Linking anonymous account to Google');
         result = await currentUser!.linkWithCredential(credential);
-      } on FirebaseAuthException catch (e) {
+      } on FirebaseAuthException catch (e, st) {
         if (e.code == 'credential-already-in-use') {
           LogService.warning(LogTag.AUTH, 'Google credential already in use, signing in directly');
           result = await _auth.signInWithCredential(credential);
         } else {
-          LogService.error(LogTag.AUTH, 'Google Sign-In link failed', e);
+          LogService.error(LogTag.AUTH, 'Step 4 FAILED: Firebase link error [${e.code}]', e, st);
           rethrow;
         }
       }
     } else {
-      result = await _auth.signInWithCredential(credential);
+      try {
+        result = await _auth.signInWithCredential(credential);
+      } catch (e, st) {
+        LogService.error(LogTag.AUTH, 'Step 4 FAILED: Firebase signIn error (${e.runtimeType})', e, st);
+        rethrow;
+      }
     }
 
-    LogService.info(LogTag.AUTH, 'Google Sign-In success: ${result.user?.email ?? result.user?.uid}');
+    LogService.info(LogTag.AUTH, 'Step 4 OK: Firebase sign-in success: ${result.user?.email ?? result.user?.uid}');
     return result.user;
   }
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import FirebaseAuth
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -9,6 +10,29 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
+
+    // Method channel: 讓 Dart 端可以呼叫 useUserAccessGroup(nil)
+    // 解決 macOS 上 Firebase Auth 的 keychain-error
+    let channel = FlutterMethodChannel(
+      name: "com.familyledger/auth_config",
+      binaryMessenger: flutterViewController.engine.binaryMessenger
+    )
+    channel.setMethodCallHandler { (call, result) in
+      if call.method == "configureKeychainAccess" {
+        do {
+          try Auth.auth().useUserAccessGroup(nil)
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "KEYCHAIN_CONFIG_ERROR",
+            message: error.localizedDescription,
+            details: nil
+          ))
+        }
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
 
     super.awakeFromNib()
   }


### PR DESCRIPTION
## Summary

- 在登入頁加入 Debug Log 入口（kDebugMode），方便排查登入問題
- 改善錯誤顯示：顯示 exception type、SelectableText、一鍵複製
- Google Sign-In 流程加入 Step 1-4 分步 log
- **修復 macOS keychain-error**：透過 MethodChannel 呼叫 `Auth.auth().useUserAccessGroup(nil)`，切換至 app-local keychain，避免 Firebase Auth v11.x 在 sandbox 關閉時的 `kSecUseDataProtectionKeychain` 問題

## Root Cause

Firebase Auth v11.x 在 macOS 10.15+ 使用 `kSecUseDataProtectionKeychain: YES`，搭配 keychain access group。當 app sandbox 關閉時，此行為不可靠。呼叫 `useUserAccessGroup(nil)` 改用 app-local keychain，不需要 access group。

## Changes

- `macos/Runner/MainFlutterWindow.swift` — 加入 MethodChannel handler，呼叫 `Auth.auth().useUserAccessGroup(nil)`
- `lib/main.dart` — Firebase 初始化後、auth 操作前，透過 MethodChannel 設定 keychain
- `lib/services/auth_service.dart` — Google Sign-In 分步 logging
- `lib/screens/auth/login_page.dart` — Debug Log 入口 + 改善錯誤顯示

## Test plan

- [ ] Xcode build 成功
- [ ] 啟動 app → console 可見 `macOS keychain access configured` log
- [ ] Google Sign-In 完整流程不再出現 keychain-error
- [ ] Debug mode 登入頁可見 Debug Log 按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)