### PR TITLE
2026-03-29 安全修復：google-services.json 與 Log 字串插值

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+# Firebase config (contains API keys - NEVER commit)
+/android/app/google-services.json
+
 # Isar generated files
 **/*.g.dart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Three split methods (equal/percentage/custom), net debt calculation with settlem
 - **Firestore Rules**: `firestore.rules` — member-only access, owner-only delete, field validation, default-deny
 - **Storage Rules**: `storage.rules` — auth required, 10MB limit, image types only
 - **Invite code**: 8-char cryptographic random (Random.secure()), 24h expiry, max 5 uses
+- **`google-services.json`**: Firebase API key config — **never commit** (已從 Git history 移除，若重新取得需手動放置於 `android/app/` 並確認已 gitignore)
 - **Deserialization**: Defensive null checks + try-catch on all Firestore → Isar merges
 - **macOS sandbox**: Disabled (`com.apple.security.app-sandbox: false`) for Keychain access compatibility
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,7 @@ void main() async {
       LogService.info(LogTag.AUTH, 'Waiting for auth session restore');
       final user = await AuthService.authStateChanges.first;
       if (user != null && !user.isAnonymous) {
-        LogService.info(LogTag.AUTH, 'Session restored: \${user.email ?? user.uid}');
+        LogService.info(LogTag.AUTH, 'Session restored: ${user.email ?? user.uid}');
         await FirebaseSyncService.initialSync();
       } else {
         LogService.info(LogTag.AUTH, 'No active session');
@@ -64,6 +64,6 @@ void main() async {
     runApp(const ProviderScope(child: FamilyLedgerApp()));
   }, (error, stack) {
     LogService.error(LogTag.APP, 'Uncaught async error', error, stack);
-    if (kDebugMode) debugPrint('Uncaught async error: \$error\n\$stack');
+    if (kDebugMode) debugPrint('Uncaught async error: $error\n$stack');
   });
 }


### PR DESCRIPTION
## 變更摘要

### 安全性
- 新增  至 ，防止 Firebase API Key 未來誤進版控
- 已從 Git history 完全移除（filter-branch 重寫）

### 修復
- 修正  中 2 處 Dart 字串插值錯誤：LogService 呼叫時  改為 ，除錯 log 現在能正確輸出使用者 email/uid 與錯誤 stack

### 改善
- 移除 macOS Podfile 中不再需要的複雜建置 workaround

## 測試
- flutter analyze: ✅ 0 errors
- flutter test: ✅ 26/26 passed

Closes #91