### PR TITLE
refactor: add Repository pattern, Auth Riverpod provider, and AppException hierarchy

### DIFF
--- a/lib/exceptions/app_exception.dart
+++ b/lib/exceptions/app_exception.dart
@@ -1,0 +1,110 @@
+// App Exception Hierarchy - 家庭記帳 App
+//
+// 統一的錯誤處理體系，支援程式化錯誤類型區分
+
+/// 基礎異常類別，所有 App 異常的根類別
+sealed class AppException implements Exception {
+  final String message;
+  final DateTime timestamp;
+  final String? stackTrace;
+
+  AppException(this.message, {String? stackTrace})
+      : timestamp = DateTime.now(),
+        stackTrace = stackTrace;
+
+  @override
+  String toString() => '$runtimeType: $message';
+}
+
+/// 認證相關異常
+class AuthException extends AppException {
+  final AuthErrorType type;
+
+  AuthException(super.message, this.type, {super.stackTrace});
+
+  @override
+  String toString() => 'AuthException($type): $message';
+}
+
+enum AuthErrorType {
+  googleSignInFailed,
+  appleSignInFailed,
+  anonymousSignInFailed,
+  linkCredentialFailed,
+  sessionExpired,
+  userNotFound,
+  insufficientPermission,
+}
+
+/// 資料同步相關異常
+class SyncException extends AppException {
+  final SyncErrorType type;
+
+  SyncException(super.message, this.type, {super.stackTrace});
+
+  @override
+  String toString() => 'SyncException($type): $message';
+}
+
+enum SyncErrorType {
+  firestoreWriteFailed,
+  firestoreReadFailed,
+  firestorePermissionDenied,
+  realtimeListenerError,
+  mergeConflict,
+  networkUnavailable,
+  offlineOperation,
+}
+
+/// 資料驗證相關異常
+class ValidationException extends AppException {
+  final String field;
+  final ValidationErrorType type;
+
+  ValidationException(
+    super.message, {
+    required this.field,
+    required this.type,
+    super.stackTrace,
+  });
+
+  @override
+  String toString() => 'ValidationException($field, $type): $message';
+}
+
+enum ValidationErrorType {
+  emptyRequired,
+  invalidFormat,
+  outOfRange,
+  tooLong,
+  duplicateEntry,
+  notFound,
+}
+
+/// 資料庫相關異常
+class DatabaseException extends AppException {
+  final DatabaseErrorType type;
+
+  DatabaseException(super.message, this.type, {super.stackTrace});
+
+  @override
+  String toString() => 'DatabaseException($type): $message';
+}
+
+enum DatabaseErrorType {
+  isarInitFailed,
+  writeTransactionFailed,
+  queryFailed,
+  schemaMismatch,
+  corruptedData,
+}
+
+/// 網路相關異常
+class NetworkException extends AppException {
+  NetworkException(super.message, {super.stackTrace});
+}
+
+/// 通用未知異常（包裝未預期錯誤）
+class UnknownException extends AppException {
+  UnknownException(super.message, {super.stackTrace});
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,0 +1,208 @@
+// Auth State Provider - 家庭記帳 App
+//
+// 將靜態 AuthService 改為 Riverpod StreamProvider
+// 支援 ref.watch(authStateProvider) 全域取用認證狀態
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import '../exceptions/app_exception.dart';
+
+/// Auth 狀態
+enum AuthStatus {
+  initial,   // 初始狀態（載入中）
+  signedIn,   // 已登入（非匿名）
+  anonymous,  // 匿名模式
+  signedOut,  // 未登入
+}
+
+class AuthState {
+  final AuthStatus status;
+  final User? user;
+  final String? errorMessage;
+
+  const AuthState({
+    this.status = AuthStatus.initial,
+    this.user,
+    this.errorMessage,
+  });
+
+  bool get isSignedIn => status == AuthStatus.signedIn;
+  bool get isAnonymous => status == AuthStatus.anonymous;
+  bool get hasAuth => user != null;
+
+  AuthState copyWith({
+    AuthStatus? status,
+    User? user,
+    String? errorMessage,
+  }) {
+    return AuthState(
+      status: status ?? this.status,
+      user: user ?? this.user,
+      errorMessage: errorMessage,
+    );
+  }
+}
+
+/// Firebase Auth instance provider
+final firebaseAuthProvider = Provider<FirebaseAuth>((ref) {
+  return FirebaseAuth.instance;
+});
+
+/// Google Sign-In instance provider
+final googleSignInProvider = Provider<GoogleSignIn>((ref) {
+  return GoogleSignIn(
+    serverClientId: '137558877215-85ak3t2lbne5iuad4aoop4fadn2m4p7u.apps.googleusercontent.com',
+  );
+});
+
+/// Auth State Stream Provider
+/// 取代靜態 AuthService.authStateChanges，全域可 ref.watch
+final authStateProvider = StreamProvider<AuthState>((ref) async* {
+  final auth = ref.watch(firebaseAuthProvider);
+
+  // 初始發射當前狀態
+  final currentUser = auth.currentUser;
+  if (currentUser != null) {
+    yield AuthState(
+      status: currentUser.isAnonymous
+          ? AuthStatus.anonymous
+          : AuthStatus.signedIn,
+      user: currentUser,
+    );
+  } else {
+    yield const AuthState(status: AuthStatus.signedOut);
+  }
+
+  // 監聽未來變化
+  await for (final user in auth.authStateChanges()) {
+    if (user == null) {
+      yield const AuthState(status: AuthStatus.signedOut);
+    } else if (user.isAnonymous) {
+      yield AuthState(status: AuthStatus.anonymous, user: user);
+    } else {
+      yield AuthState(status: AuthStatus.signedIn, user: user);
+    }
+  }
+});
+
+/// 同步取得當前 Auth 狀態（一次性查詢）
+final currentAuthProvider = FutureProvider<AuthState>((ref) async {
+  final auth = ref.watch(firebaseAuthProvider);
+  final user = auth.currentUser;
+  if (user == null) {
+    return const AuthState(status: AuthStatus.signedOut);
+  }
+  return AuthState(
+    status: user.isAnonymous ? AuthStatus.anonymous : AuthStatus.signedIn,
+    user: user,
+  );
+});
+
+/// Auth Operations Notifier（處理登入/登出操作）
+class AuthNotifier extends StateNotifier<AuthState> {
+  final FirebaseAuth _auth;
+  final GoogleSignIn _googleSignIn;
+
+  AuthNotifier(this._auth, this._googleSignIn) : super(const AuthState()) {
+    _auth.authStateChanges().listen((user) {
+      if (user == null) {
+        state = const AuthState(status: AuthStatus.signedOut);
+      } else if (user.isAnonymous) {
+        state = AuthState(status: AuthStatus.anonymous, user: user);
+      } else {
+        state = AuthState(status: AuthStatus.signedIn, user: user);
+      }
+    });
+  }
+
+  Future<void> signInWithGoogle() async {
+    state = state.copyWith(status: AuthStatus.initial, errorMessage: null);
+    try {
+      final googleUser = await _googleSignIn.signIn();
+      if (googleUser == null) {
+        state = const AuthState(status: AuthStatus.signedOut);
+        return;
+      }
+
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+
+      final userCredential = await _auth.signInWithCredential(credential);
+      state = AuthState(
+        status: AuthStatus.signedIn,
+        user: userCredential.user,
+      );
+    } on FirebaseAuthException catch (e) {
+      state = AuthState(
+        status: AuthStatus.signedOut,
+        errorMessage: e.message,
+      );
+      throw AuthException(
+        e.message ?? 'Google 登入失敗',
+        AuthErrorType.googleSignInFailed,
+        stackTrace: e.stackTrace?.toString(),
+      );
+    } catch (e, st) {
+      state = AuthState(
+        status: AuthStatus.signedOut,
+        errorMessage: e.toString(),
+      );
+      throw AuthException(
+        e.toString(),
+        AuthErrorType.googleSignInFailed,
+        stackTrace: st.toString(),
+      );
+    }
+  }
+
+  Future<void> signInAnonymously() async {
+    try {
+      final userCredential = await _auth.signInAnonymously();
+      state = AuthState(
+        status: AuthStatus.anonymous,
+        user: userCredential.user,
+      );
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(
+        e.message ?? '匿名登入失敗',
+        AuthErrorType.anonymousSignInFailed,
+        stackTrace: e.stackTrace?.toString(),
+      );
+    }
+  }
+
+  Future<void> linkWithGoogleCredential(AuthCredential credential) async {
+    try {
+      final userCredential = await _auth.currentUser?.linkWithCredential(credential);
+      if (userCredential != null) {
+        state = AuthState(
+          status: AuthStatus.signedIn,
+          user: userCredential.user,
+        );
+      }
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(
+        e.message ?? '連結帳戶失敗',
+        AuthErrorType.linkCredentialFailed,
+        stackTrace: e.stackTrace?.toString(),
+      );
+    }
+  }
+
+  Future<void> signOut() async {
+    await _googleSignIn.signOut();
+    await _auth.signOut();
+    state = const AuthState(status: AuthStatus.signedOut);
+  }
+}
+
+/// Auth Notifier Provider
+final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  final auth = ref.watch(firebaseAuthProvider);
+  final googleSignIn = ref.watch(googleSignInProvider);
+  return AuthNotifier(auth, googleSignIn);
+});

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,0 +1,38 @@
+// Expense Repository Interface - 家庭記帳 App
+//
+// 定義 Expense 資料的抽象介面，支援本地 Isar 和遠端 Firestore
+
+import '../models/expense.dart';
+
+/// Expense 資料存取介面
+abstract class ExpenseRepository {
+  /// 取得所有支出（依日期降序）
+  Stream<List<Expense>> watchAllExpenses();
+
+  /// 取得本月支出（依日期降序）
+  Stream<List<Expense>> watchMonthlyExpenses({int? year, int? month});
+
+  /// 取得最近 N 筆支出
+  Stream<List<Expense>> watchRecentExpenses(int count);
+
+  /// 依 ID 取得支出
+  Future<Expense?> getExpenseById(String id);
+
+  /// 依群組 ID 取得所有支出
+  Future<List<Expense>> getExpensesByGroupId(String groupId);
+
+  /// 新增支出
+  Future<void> addExpense(Expense expense);
+
+  /// 更新支出
+  Future<void> updateExpense(Expense expense);
+
+  /// 刪除支出
+  Future<void> deleteExpense(int isarId);
+
+  /// 批次刪除支出（依群組）
+  Future<void> deleteExpensesByGroupId(String groupId);
+
+  /// 搜尋支出描述（自動完成用）
+  Future<List<String>> searchRecentDescriptions({int limit = 200});
+}

--- a/lib/repositories/isar_expense_repository.dart
+++ b/lib/repositories/isar_expense_repository.dart
@@ -1,0 +1,88 @@
+// Isar Expense Repository Implementation - 家庭記帳 App
+//
+// Isar 本地資料庫的 Expense 實作
+
+import 'package:isar/isar.dart';
+import '../models/expense.dart';
+import 'expense_repository.dart';
+
+class IsarExpenseRepository implements ExpenseRepository {
+  final Isar _isar;
+
+  IsarExpenseRepository(this._isar);
+
+  @override
+  Stream<List<Expense>> watchAllExpenses() {
+    return _isar.expenses.where().sortByDateDesc().watch(fireImmediately: true);
+  }
+
+  @override
+  Stream<List<Expense>> watchMonthlyExpenses({int? year, int? month}) {
+    final now = DateTime.now();
+    final startOfMonth = DateTime(year ?? now.year, month ?? now.month, 1);
+    final endOfMonth = DateTime(year ?? now.year, month ?? now.month + 1, 0, 23, 59, 59);
+    return _isar.expenses
+        .filter()
+        .dateBetween(startOfMonth, endOfMonth)
+        .sortByDateDesc()
+        .watch(fireImmediately: true);
+  }
+
+  @override
+  Stream<List<Expense>> watchRecentExpenses(int count) {
+    return _isar.expenses.where().sortByDateDesc().limit(count).watch(fireImmediately: true);
+  }
+
+  @override
+  Future<Expense?> getExpenseById(String id) {
+    return _isar.expenses.filter().idEqualTo(id).findFirst();
+  }
+
+  @override
+  Future<List<Expense>> getExpensesByGroupId(String groupId) {
+    return _isar.expenses.filter().groupIdEqualTo(groupId).sortByDateDesc().findAll();
+  }
+
+  @override
+  Future<void> addExpense(Expense expense) async {
+    await _isar.writeTxn(() async {
+      await _isar.expenses.put(expense);
+    });
+  }
+
+  @override
+  Future<void> updateExpense(Expense expense) async {
+    expense.updatedAt = DateTime.now();
+    await _isar.writeTxn(() async {
+      await _isar.expenses.put(expense);
+    });
+  }
+
+  @override
+  Future<void> deleteExpense(int isarId) async {
+    await _isar.writeTxn(() async {
+      await _isar.expenses.delete(isarId);
+    });
+  }
+
+  @override
+  Future<void> deleteExpensesByGroupId(String groupId) async {
+    await _isar.writeTxn(() async {
+      await _isar.expenses.filter().groupIdEqualTo(groupId).deleteAll();
+    });
+  }
+
+  @override
+  Future<List<String>> searchRecentDescriptions({int limit = 200}) async {
+    final expenses = await _isar.expenses
+        .where()
+        .sortByDateDesc()
+        .limit(limit)
+        .findAll();
+    final seen = <String>{};
+    return expenses
+        .map((e) => e.description)
+        .where((d) => d.isNotEmpty && seen.add(d))
+        .toList();
+  }
+}

--- a/lib/repositories/repository_providers.dart
+++ b/lib/repositories/repository_providers.dart
@@ -1,0 +1,32 @@
+// Repository Providers - 家庭記帳 App
+//
+// 將所有 Repository 介面綁定到 Riverpod Provider
+// 支援依賴注入和單元測試 mock
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar/isar.dart';
+import '../services/database_service.dart';
+import 'expense_repository.dart';
+import 'isar_expense_repository.dart';
+
+/// Isar 資料庫實例 Provider
+final isarProvider = FutureProvider<Isar>((ref) async {
+  return await DatabaseService.instance;
+});
+
+/// Expense Repository Provider
+/// 使用 IsarExpenseRepository 作為實作
+final expenseRepositoryProvider = Provider<ExpenseRepository>((ref) {
+  final isarAsync = ref.watch(isarProvider);
+  return isarAsync.when(
+        data: (isar) => IsarExpenseRepository(isar),
+        loading: () => throw StateError('Isar not initialized yet'),
+        error: (e, _) => throw StateError('Isar init failed: $e'),
+      );
+});
+
+/// Expense Repository Stream Provider（用於需持续监听的场景）
+final expenseRepositoryStreamProvider = StreamProvider<ExpenseRepository>((ref) async* {
+  final isar = await DatabaseService.instance;
+  yield IsarExpenseRepository(isar);
+});


### PR DESCRIPTION
## Phase 1 of Architecture Overhaul

### Changes

**1. AppException Hierarchy** (`lib/exceptions/app_exception.dart`)
- Sealed class `AppException` as root with 6 subtypes:
  - `AuthException` - authentication errors
  - `SyncException` - Firebase sync errors
  - `ValidationException` - data validation errors
  - `DatabaseException` - Isar DB errors
  - `NetworkException` - network connectivity errors
  - `UnknownException` - catch-all for unexpected errors
- Enables exhaustive error handling with `when` expressions

**2. Repository Pattern** (`lib/repositories/`)
- `ExpenseRepository` interface defining data access contract
- `IsarExpenseRepository` implementation
- `Repository providers` for dependency injection and unit test mocking

**3. Auth Riverpod Provider** (`lib/providers/auth_provider.dart`)
- `authStateProvider` (StreamProvider) - reactive auth state, replaces `AuthService.authStateChanges.first`
- `authNotifierProvider` (StateNotifierProvider) - login/logout operations
- `FirebaseAuth` and `GoogleSignIn` as injectable providers

### Impact
- LOW: New files only, no breaking changes to existing code
- All new providers are additive

Closes #93